### PR TITLE
fix: allow browsing/queuing skaters during goalie/ref pick rounds

### DIFF
--- a/frontend/src/views/FantasyLeagueView.vue
+++ b/frontend/src/views/FantasyLeagueView.vue
@@ -178,7 +178,7 @@
                 <!-- Skater / Goalie sub-tabs -->
                 <div class="tabs tabs-boxed tabs-xs mb-3 w-fit">
                   <button class="tab" :class="{ 'tab-active': poolTab === 'skaters' }" @click="poolTab = 'skaters'"
-                    :disabled="currentPick?.is_goalie_pick || currentPick?.is_ref_pick">
+                    :disabled="currentPick?.user_id === myUserId && (currentPick?.is_goalie_pick || currentPick?.is_ref_pick)">
                     Skaters
                   </button>
                   <button class="tab" :class="{ 'tab-active': poolTab === 'goalies' }" @click="poolTab = 'goalies'"
@@ -217,7 +217,7 @@
                           <span v-if="p.drafted_by" class="text-xs text-base-content/40">{{ p.drafted_by.team_name }}</span>
                           <template v-else-if="currentPick && currentPick.user_id === myUserId && league.is_member">
                             <div class="flex items-center gap-1">
-                              <button class="btn btn-xs btn-primary" :disabled="picking" @click="pickPlayer(p)">Draft</button>
+                              <button v-if="!currentPick.is_goalie_pick && !currentPick.is_ref_pick" class="btn btn-xs btn-primary" :disabled="picking" @click="pickPlayer(p)">Draft</button>
                               <button
                                 class="btn btn-xs"
                                 :class="queuePositionOf(p.hb_human_id) ? 'btn-warning' : 'btn-ghost opacity-40'"


### PR DESCRIPTION
## Bug
Skater tab was greyed out for ALL managers whenever it was a goalie or ref pick round — even managers who aren't currently picking and just want to browse or star players for their queue.

## Root Cause
The disabled condition on the Skaters tab was:
```
:disabled="currentPick?.is_goalie_pick || currentPick?.is_ref_pick"
```

It was missing the `user_id === myUserId` guard that the Goalies and Refs tabs already have correctly. So any time round 1 (goalie round) was active, everyone's Skater tab got locked.

## Fix
- Skater tab: only disable when it's **your** turn AND it's a goalie/ref pick
- Skater Draft button: hide (not just disable) when it's your turn but it's a goalie/ref pick round — you can still ☆ queue skaters, just can't draft them in the wrong round

## Behavior After Fix
- During goalie round: other managers can freely browse Skaters and star them into queue ✅
- During goalie round: the picking manager's Skater tab is still locked (correct) ✅  
- During goalie round: the picking manager can see Skater list but Draft button is hidden ✅
- Backend still enforces pick type validation as a safety net ✅