### PR TITLE
feat: auto-pick from priority queue + silent draft polling

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -61,9 +61,17 @@ def create_app(config_name: str | None = None) -> Flask:
     _register_blueprints(app)
 
     # ── Background scheduler ───────────────────────────────────────────────────
-    if not app.config.get("TESTING") and os.environ.get("WERKZEUG_RUN_MAIN") != "false":
-        # Only start scheduler in the main process (not the reloader child)
-        if not app.debug or os.environ.get("WERKZEUG_RUN_MAIN") == "true":
+    if not app.config.get("TESTING"):
+        # Start scheduler once per process.
+        # - Gunicorn: preload_app=True loads this in master; post_fork shuts it down in workers.
+        # - Flask dev server: werkzeug reloader fires twice; only start in the child (WERKZEUG_RUN_MAIN=true).
+        # - Any other runner (pytest excluded via TESTING): always start.
+        _werkzeug_main = os.environ.get("WERKZEUG_RUN_MAIN")
+        _should_start = (
+            _werkzeug_main is None   # gunicorn or direct python run
+            or _werkzeug_main == "true"  # werkzeug reloader child
+        )
+        if _should_start:
             from app.jobs.grade_results import start_scheduler
             start_scheduler(app)
             from app.services.event_tracker import start_tracker

--- a/app/blueprints/admin.py
+++ b/app/blueprints/admin.py
@@ -861,6 +861,7 @@ def delete_fantasy_league(league_id: int):
     from sqlalchemy import select, delete as sa_delete
     from app.models.fantasy_league import FantasyLeague
     from app.models.fantasy_manager import FantasyManager
+    from app.models.fantasy_manager_queue import FantasyManagerQueue
     from app.models.fantasy_roster import FantasyRoster
     from app.models.fantasy_draft_queue import FantasyDraftQueue
     from app.models.fantasy_standings import FantasyStandings
@@ -879,6 +880,7 @@ def delete_fantasy_league(league_id: int):
     pred.execute(sa_delete(FantasyStandings).where(FantasyStandings.league_id == league_id))
     pred.execute(sa_delete(FantasyDraftQueue).where(FantasyDraftQueue.league_id == league_id))
     pred.execute(sa_delete(FantasyRoster).where(FantasyRoster.league_id == league_id))
+    pred.execute(sa_delete(FantasyManagerQueue).where(FantasyManagerQueue.league_id == league_id))
     pred.execute(sa_delete(FantasyManager).where(FantasyManager.league_id == league_id))
     pred.delete(league)
     pred.commit()
@@ -893,6 +895,7 @@ def batch_delete_fantasy_leagues():
     from sqlalchemy import delete as sa_delete
     from app.models.fantasy_league import FantasyLeague
     from app.models.fantasy_manager import FantasyManager
+    from app.models.fantasy_manager_queue import FantasyManagerQueue
     from app.models.fantasy_roster import FantasyRoster
     from app.models.fantasy_draft_queue import FantasyDraftQueue
     from app.models.fantasy_standings import FantasyStandings
@@ -912,6 +915,7 @@ def batch_delete_fantasy_leagues():
     pred.execute(sa_delete(FantasyStandings).where(FantasyStandings.league_id.in_(league_ids)))
     pred.execute(sa_delete(FantasyDraftQueue).where(FantasyDraftQueue.league_id.in_(league_ids)))
     pred.execute(sa_delete(FantasyRoster).where(FantasyRoster.league_id.in_(league_ids)))
+    pred.execute(sa_delete(FantasyManagerQueue).where(FantasyManagerQueue.league_id.in_(league_ids)))
     pred.execute(sa_delete(FantasyManager).where(FantasyManager.league_id.in_(league_ids)))
     pred.execute(sa_delete(FantasyLeague).where(FantasyLeague.id.in_(league_ids)))
     pred.commit()

--- a/app/blueprints/fantasy.py
+++ b/app/blueprints/fantasy.py
@@ -294,8 +294,10 @@ def create_league():
     except Exception as e:
         return error_response("INTERNAL_ERROR", f"Could not load player pool: {e}", 500)
 
-    # Capture the resolved season_id so scoring works correctly
-    hb_season_id = pool_info.get("resolved_season_id")
+    # draft_season_id = season used to build the player pool (past season, rich stats)
+    # hb_season_id = season used for live scoring (starts NULL, auto-assigned when play season starts)
+    draft_season_id = pool_info.get("resolved_season_id")
+    hb_season_id = None  # will be auto-assigned by scoring service when play season begins
 
     roster_skaters = pool_info["roster_skaters"]
     max_managers = pool_info["max_managers"]
@@ -349,7 +351,8 @@ def create_league():
             level_id=level_id,
             level_name=level_name,
             hb_league_id=hb_league_id,
-            hb_season_id=hb_season_id,
+            hb_season_id=hb_season_id,  # NULL — auto-assigned when play season starts
+            draft_season_id=draft_season_id,  # locked to draft pool season
             org_id=level.org_id,
             season_label=data.get("season_label"),
             status="forming",
@@ -657,7 +660,7 @@ def get_pool(league_id: int):
 
     from app.services.fantasy_pool_service import get_player_pool
     try:
-        pool = get_player_pool(league.level_id, org_id=league.org_id, league_id=league.hb_league_id, season_id=league.hb_season_id)
+        pool = get_player_pool(league.level_id, org_id=league.org_id, league_id=league.hb_league_id, season_id=league.draft_season_id or league.hb_season_id)
     except Exception as e:
         return error_response("INTERNAL_ERROR", str(e), 500)
 

--- a/app/blueprints/fantasy.py
+++ b/app/blueprints/fantasy.py
@@ -831,6 +831,65 @@ def save_my_draft_queue(league_id: int):
     return jsonify({"ok": True, "count": len(deduped)})
 
 
+@fantasy_bp.route("/leagues/<int:league_id>/draft/process-queue", methods=["POST"])
+@require_auth
+def process_draft_queue(league_id: int):
+    """POST /api/fantasy/leagues/<id>/draft/process-queue
+    Called by the frontend when it's the user's turn and they have a queue.
+    Triggers auto-pick from queue immediately if conditions are met.
+    Returns {"picked": true/false, "player": {...}} so the frontend can refresh.
+    """
+    from app.models.fantasy_draft_queue import FantasyDraftQueue
+    from app.services.fantasy_draft_service import _best_available_from_queue_only, _record_pick, _set_next_deadline, _compute_pick_hours
+    from sqlalchemy import select
+    from datetime import datetime, timezone
+
+    user_id = g.pred_user.id
+    pred = PredSession()
+    league = pred.get(FantasyLeague, league_id)
+
+    if league is None or league.status not in ("draft_open", "drafting"):
+        return jsonify({"picked": False, "reason": "draft not active"})
+
+    # Get current pick
+    stmt = (
+        select(FantasyDraftQueue)
+        .where(
+            FantasyDraftQueue.league_id == league_id,
+            FantasyDraftQueue.hb_human_id.is_(None),
+            FantasyDraftQueue.is_skipped == False,  # noqa: E712
+        )
+        .order_by(FantasyDraftQueue.overall_pick.asc())
+        .limit(1)
+    )
+    current = pred.execute(stmt).scalar_one_or_none()
+
+    if current is None or current.user_id != user_id:
+        return jsonify({"picked": False, "reason": "not your turn"})
+
+    best = _best_available_from_queue_only(league_id, user_id, pred, league, current_slot=current)
+    if best is None:
+        return jsonify({"picked": False, "reason": "no queue match"})
+
+    now = datetime.now(timezone.utc)
+    current.deadline = now
+    pred.commit()
+    _record_pick(league_id, current, best["hb_human_id"],
+        is_goalie=current.is_goalie_pick and best.get("is_goalie", False),
+        pred=pred, now=now,
+        is_ref=current.is_ref_pick and best.get("is_ref", False))
+
+    if league.status == "draft_open":
+        league.status = "drafting"
+        league.draft_started_at = now
+        pred.commit()
+
+    _set_next_deadline(league_id, pred, _compute_pick_hours(league))
+
+    return jsonify({"picked": True, "player": {"hb_human_id": best["hb_human_id"],
+        "first_name": best.get("first_name"), "last_name": best.get("last_name")}})
+
+
 @fantasy_bp.route("/leagues/<int:league_id>/roster/<int:user_id>", methods=["GET"])
 @optional_auth
 def get_roster(league_id: int, user_id: int):

--- a/app/blueprints/fantasy.py
+++ b/app/blueprints/fantasy.py
@@ -607,10 +607,13 @@ def join_league(league_id: int):
         pred.add(mgr)
         pred.commit()
 
-        # Auto-open draft when league hits max_managers
+        # When league hits max_managers, assign draft positions.
+        # Only auto-open immediately if draft_opens_at is already past (or not set).
+        # Otherwise stay in "forming" so managers can build their queues until scheduled time.
         new_count = mgr_count + 1
         if new_count >= league.max_managers and league.status == "forming":
             import random as _random
+            from datetime import datetime, timezone as _tz
             managers = pred.execute(
                 select(FantasyManager).where(FantasyManager.league_id == league_id)
             ).scalars().all()
@@ -618,14 +621,21 @@ def join_league(league_id: int):
             _random.shuffle(positions)
             for m, pos in zip(managers, positions):
                 m.draft_position = pos
-            league.status = "draft_open"
-            pred.commit()
 
-            from app.services.fantasy_draft_service import build_draft_queue
-            try:
-                build_draft_queue(league_id)
-            except Exception as e:
-                pass  # draft queue build failure shouldn't block the join response
+            now_utc = datetime.now(_tz.utc)
+            opens_at = league.draft_opens_at
+            if opens_at is None or opens_at <= now_utc:
+                # No scheduled time or already past — open immediately
+                league.status = "draft_open"
+                pred.commit()
+                from app.services.fantasy_draft_service import build_draft_queue
+                try:
+                    build_draft_queue(league_id)
+                except Exception:
+                    pass
+            else:
+                # Scheduled time in the future — stay forming, managers can build queues
+                pred.commit()
 
     except Exception as e:
         pred.rollback()

--- a/app/blueprints/fantasy.py
+++ b/app/blueprints/fantasy.py
@@ -232,6 +232,8 @@ def get_level_pool():
         return jsonify({
             "max_managers": pool["max_managers"],
             "roster_skaters": pool["roster_skaters"],
+            "resolved_season_id": pool.get("resolved_season_id"),
+            "resolved_season_name": pool.get("resolved_season_name"),
         })
     except Exception as e:
         return jsonify({"max_managers": 12, "roster_skaters": 8})  # fallback

--- a/app/jobs/grade_results.py
+++ b/app/jobs/grade_results.py
@@ -141,6 +141,67 @@ def start_scheduler(app):
         replace_existing=True,
     )
 
+    def _draft_open_job():
+        """
+        Auto-open drafts whose draft_opens_at has passed and are still forming.
+        Runs every minute.
+        """
+        with _app.app_context():
+            try:
+                import random as _random
+                from datetime import datetime, timezone as _tz
+                from sqlalchemy import select
+                from app.db import PredSession
+                from app.models.fantasy_league import FantasyLeague
+                from app.models.fantasy_manager import FantasyManager
+                from app.services.fantasy_draft_service import build_draft_queue
+
+                pred = PredSession()
+                now = datetime.now(_tz.utc)
+                ready = pred.execute(
+                    select(FantasyLeague).where(
+                        FantasyLeague.status == "forming",
+                        FantasyLeague.draft_opens_at <= now,
+                        FantasyLeague.draft_opens_at.isnot(None),
+                    )
+                ).scalars().all()
+
+                for league in ready:
+                    from sqlalchemy import func as _func
+                    mgr_count = pred.execute(
+                        select(_func.count()).select_from(FantasyManager).where(
+                            FantasyManager.league_id == league.id
+                        )
+                    ).scalar_one()
+                    if mgr_count < 2:
+                        continue  # not enough managers yet
+                    managers = pred.execute(
+                        select(FantasyManager).where(FantasyManager.league_id == league.id)
+                    ).scalars().all()
+                    # Assign positions only if not already assigned
+                    if all(m.draft_position is None for m in managers):
+                        positions = list(range(1, len(managers) + 1))
+                        _random.shuffle(positions)
+                        for m, pos in zip(managers, positions):
+                            m.draft_position = pos
+                    league.status = "draft_open"
+                    pred.commit()
+                    try:
+                        build_draft_queue(league.id)
+                        logger.info("[draft] Auto-opened league %d at scheduled time", league.id)
+                    except Exception as e:
+                        logger.warning("[draft] build_draft_queue(%d) error: %s", league.id, e)
+            except Exception as exc:
+                logger.exception("[draft] Unhandled error in draft open job: %s", exc)
+
+    _scheduler.add_job(
+        func=_draft_open_job,
+        trigger=IntervalTrigger(minutes=1),
+        id="open_drafts",
+        name="Auto-open forming drafts at scheduled time",
+        replace_existing=True,
+    )
+
     def _draft_advance_job():
         """
         Check all active drafts for expired pick deadlines.

--- a/app/services/fantasy_draft_service.py
+++ b/app/services/fantasy_draft_service.py
@@ -538,11 +538,11 @@ def _picks_remaining_for_manager(league_id: int, user_id: int, pred) -> int:
 
 
 def _get_pool(league_id: int) -> dict:
-    """Get the level pool for this league."""
+    """Get the level pool for this league (always uses draft_season_id, not play season)."""
     from app.services.fantasy_pool_service import get_player_pool
     pred = PredSession()
     league = pred.get(FantasyLeague, league_id)
-    return get_player_pool(league.level_id, org_id=league.org_id, league_id=league.hb_league_id, season_id=league.hb_season_id)
+    return get_player_pool(league.level_id, org_id=league.org_id, league_id=league.hb_league_id, season_id=league.draft_season_id or league.hb_season_id)
 
 
 def _clear_stale_draft_notifications(user_id: int, league_id: int, pred) -> None:

--- a/app/services/fantasy_draft_service.py
+++ b/app/services/fantasy_draft_service.py
@@ -178,19 +178,32 @@ def _set_next_deadline(league_id: int, pred, pick_hours: int, prev_was_auto: boo
 
     If the next manager has a non-empty priority queue with an available player,
     auto-pick immediately on their behalf instead of waiting for them.
+    Loops (not recurses) to chain auto-picks safely across many managers.
     """
-    stmt = (
-        select(FantasyDraftQueue)
-        .where(
-            FantasyDraftQueue.league_id == league_id,
-            FantasyDraftQueue.hb_human_id.is_(None),
-            FantasyDraftQueue.is_skipped == False,  # noqa: E712
+    MAX_AUTO_PICKS = 500  # hard safety cap — full draft is n_managers * total_rounds
+
+    for _ in range(MAX_AUTO_PICKS):
+        stmt = (
+            select(FantasyDraftQueue)
+            .where(
+                FantasyDraftQueue.league_id == league_id,
+                FantasyDraftQueue.hb_human_id.is_(None),
+                FantasyDraftQueue.is_skipped == False,  # noqa: E712
+            )
+            .order_by(FantasyDraftQueue.overall_pick.asc())
+            .limit(1)
         )
-        .order_by(FantasyDraftQueue.overall_pick.asc())
-        .limit(1)
-    )
-    slot = pred.execute(stmt).scalar_one_or_none()
-    if slot:
+        slot = pred.execute(stmt).scalar_one_or_none()
+        if not slot:
+            # No more unpicked slots — draft is complete, mark league active
+            league = pred.get(FantasyLeague, league_id)
+            if league and league.status == "drafting":
+                league.status = "active"
+                if not league.draft_season_id:
+                    league.draft_season_id = league.hb_season_id
+                pred.commit()
+            return
+
         league = pred.get(FantasyLeague, league_id)
 
         # Check if this manager has a queued player ready — if so, auto-pick immediately
@@ -201,35 +214,25 @@ def _set_next_deadline(league_id: int, pred, pick_hours: int, prev_was_auto: boo
                 league_id, slot.overall_pick, slot.user_id, best["hb_human_id"],
             )
             now = datetime.now(timezone.utc)
-            slot.deadline = now  # set deadline to now before picking
+            slot.deadline = now
             pred.commit()
             _record_pick(league_id, slot, best["hb_human_id"],
                 is_goalie=slot.is_goalie_pick and best.get("is_goalie", False),
                 pred=pred, now=now,
                 is_ref=slot.is_ref_pick and best.get("is_ref", False))
-            # Notify them that we auto-picked from their queue
             _notify_manager(slot.user_id, league_id, slot.overall_pick, now, pred, auto_picked_from_queue=True)
-            # Transition league to drafting if needed
             if league and league.status == "draft_open":
                 league.status = "drafting"
                 league.draft_started_at = now
                 pred.commit()
-            # Recurse to set deadline on the NEXT pick (may also auto-pick)
-            _set_next_deadline(league_id, pred, pick_hours, prev_was_auto=prev_was_auto)
-            return
+            # Loop to check the next pick
+            continue
 
+        # No queue hit — set deadline and wait for manual pick
         slot.deadline = _deadline_respecting_quiet_hours(pick_hours)
         pred.commit()
-        # Notify the manager it's their turn
         _notify_manager(slot.user_id, slot.league_id, slot.overall_pick, slot.deadline, pred)
-    else:
-        # No more unpicked slots — draft is complete, mark league active
-        league = pred.get(FantasyLeague, league_id)
-        if league and league.status == "drafting":
-            league.status = "active"
-            if not league.draft_season_id:
-                league.draft_season_id = league.hb_season_id
-            pred.commit()
+        return
 
 
 def advance_draft(league_id: int) -> None:

--- a/app/services/fantasy_draft_service.py
+++ b/app/services/fantasy_draft_service.py
@@ -174,7 +174,11 @@ def build_draft_queue(league_id: int) -> None:
 
 
 def _set_next_deadline(league_id: int, pred, pick_hours: int, prev_was_auto: bool = False) -> None:
-    """Set deadline on the first unpicked, non-skipped slot."""
+    """Set deadline on the first unpicked, non-skipped slot.
+
+    If the next manager has a non-empty priority queue with an available player,
+    auto-pick immediately on their behalf instead of waiting for them.
+    """
     stmt = (
         select(FantasyDraftQueue)
         .where(
@@ -187,10 +191,36 @@ def _set_next_deadline(league_id: int, pred, pick_hours: int, prev_was_auto: boo
     )
     slot = pred.execute(stmt).scalar_one_or_none()
     if slot:
+        league = pred.get(FantasyLeague, league_id)
+
+        # Check if this manager has a queued player ready — if so, auto-pick immediately
+        best = _best_available_from_queue_only(league_id, slot.user_id, pred, league, current_slot=slot)
+        if best is not None:
+            logger.info(
+                "[draft] league=%d pick=%d user=%d — queue hit, auto-picking hb_human_id=%d",
+                league_id, slot.overall_pick, slot.user_id, best["hb_human_id"],
+            )
+            now = datetime.now(timezone.utc)
+            slot.deadline = now  # set deadline to now before picking
+            pred.commit()
+            _record_pick(league_id, slot, best["hb_human_id"],
+                is_goalie=slot.is_goalie_pick and best.get("is_goalie", False),
+                pred=pred, now=now,
+                is_ref=slot.is_ref_pick and best.get("is_ref", False))
+            # Notify them that we auto-picked from their queue
+            _notify_manager(slot.user_id, league_id, slot.overall_pick, now, pred, auto_picked_from_queue=True)
+            # Transition league to drafting if needed
+            if league and league.status == "draft_open":
+                league.status = "drafting"
+                league.draft_started_at = now
+                pred.commit()
+            # Recurse to set deadline on the NEXT pick (may also auto-pick)
+            _set_next_deadline(league_id, pred, pick_hours, prev_was_auto=prev_was_auto)
+            return
+
         slot.deadline = _deadline_respecting_quiet_hours(pick_hours)
         pred.commit()
-        # If previous pick was auto (timeout), notify the skipped manager immediately
-        # then notify the next manager normally
+        # Notify the manager it's their turn
         _notify_manager(slot.user_id, slot.league_id, slot.overall_pick, slot.deadline, pred)
     else:
         # No more unpicked slots — draft is complete, mark league active
@@ -381,6 +411,46 @@ def _record_pick(league_id, slot, hb_human_id, is_goalie, pred, now, is_ref=Fals
     pred.commit()
 
 
+def _best_available_from_queue_only(league_id: int, user_id: int, pred, league, current_slot=None) -> dict | None:
+    """Return the first available player from the manager's priority queue only.
+    Returns None if queue is empty or no queued player is available for this pick type.
+    Does NOT fall back to best-by-points — that's for timeout auto-picks only.
+    """
+    from app.models.fantasy_manager_queue import FantasyManagerQueue
+    queue_stmt = (
+        select(FantasyManagerQueue)
+        .where(
+            FantasyManagerQueue.league_id == league_id,
+            FantasyManagerQueue.user_id == user_id,
+        )
+        .order_by(FantasyManagerQueue.position.asc())
+    )
+    queue_items = pred.execute(queue_stmt).scalars().all()
+    if not queue_items:
+        return None  # no queue — wait for manual pick
+
+    pool = _get_pool(league_id)
+    drafted_stmt = select(FantasyRoster.hb_human_id).where(FantasyRoster.league_id == league_id)
+    drafted_ids = set(pred.execute(drafted_stmt).scalars().all())
+
+    is_goalie_pick = current_slot.is_goalie_pick if current_slot else False
+    is_ref_pick = current_slot.is_ref_pick if current_slot else False
+
+    if is_goalie_pick:
+        eligible = {p["hb_human_id"]: p for p in pool["goalies"] if p["hb_human_id"] not in drafted_ids}
+    elif is_ref_pick:
+        eligible = {p["hb_human_id"]: p for p in pool.get("refs", []) if p["hb_human_id"] not in drafted_ids}
+    else:
+        all_skaters = [p for p in pool["skaters"] if p["hb_human_id"] not in drafted_ids]
+        eligible = {p["hb_human_id"]: p for p in all_skaters}
+
+    for item in queue_items:
+        if item.hb_human_id in eligible:
+            return eligible[item.hb_human_id]
+
+    return None  # queue exists but all queued players are already drafted or wrong type
+
+
 def _best_available(league_id: int, user_id: int, pred, league, current_slot=None) -> dict | None:
     """Return the best available (undrafted) player.
 
@@ -486,11 +556,12 @@ def _clear_stale_draft_notifications(user_id: int, league_id: int, pred) -> None
 
 
 def _notify_manager(user_id: int, league_id: int, pick_number: int, deadline: datetime, pred,
-                    auto_picked: bool = False) -> None:
+                    auto_picked: bool = False, auto_picked_from_queue: bool = False) -> None:
     """
     Notify a manager it's their turn to pick.
     - Normal turn: SMS fires after 2 min if they haven't opened the app
-    - Auto-picked on their behalf: SMS fires immediately (they're clearly not watching)
+    - Auto-picked on timeout: SMS fires immediately (they missed their turn)
+    - Auto-picked from queue: SMS fires immediately (picked from their priority queue)
     """
     try:
         _clear_stale_draft_notifications(user_id, league_id, pred)
@@ -506,7 +577,11 @@ def _notify_manager(user_id: int, league_id: int, pick_number: int, deadline: da
         except Exception:
             pass
 
-        if auto_picked:
+        if auto_picked_from_queue:
+            title = f"🏒 Picked from your queue!{league_name}"
+            body = f"Pick #{pick_number} was made automatically from your priority queue. Check your roster."
+            delay = 0  # immediate
+        elif auto_picked:
             title = f"🏒 Auto-picked for you!{league_name}"
             body = f"Pick #{pick_number} was made automatically (you missed your turn). Check your roster."
             delay = 0  # immediate — they need to know

--- a/app/services/fantasy_draft_service.py
+++ b/app/services/fantasy_draft_service.py
@@ -220,7 +220,9 @@ def _set_next_deadline(league_id: int, pred, pick_hours: int, prev_was_auto: boo
                 is_goalie=slot.is_goalie_pick and best.get("is_goalie", False),
                 pred=pred, now=now,
                 is_ref=slot.is_ref_pick and best.get("is_ref", False))
-            _notify_manager(slot.user_id, league_id, slot.overall_pick, now, pred, auto_picked_from_queue=True)
+            _player_name = f"{best.get('first_name', '')} {best.get('last_name', '')}".strip() or None
+            _notify_manager(slot.user_id, league_id, slot.overall_pick, now, pred,
+                            auto_picked_from_queue=True, player_name=_player_name)
             if league and league.status == "draft_open":
                 league.status = "drafting"
                 league.draft_started_at = now
@@ -285,9 +287,10 @@ def advance_draft(league_id: int) -> None:
             is_ref=current.is_ref_pick and best.get("is_ref", False))
 
         # Notify the manager that we picked for them (immediate SMS)
+        _timeout_player_name = f"{best.get('first_name', '')} {best.get('last_name', '')}".strip() or None
         _notify_manager(
             current.user_id, league_id, current.overall_pick,
-            current.deadline, pred, auto_picked=True
+            current.deadline, pred, auto_picked=True, player_name=_timeout_player_name
         )
 
         # Award compensatory pick
@@ -559,7 +562,8 @@ def _clear_stale_draft_notifications(user_id: int, league_id: int, pred) -> None
 
 
 def _notify_manager(user_id: int, league_id: int, pick_number: int, deadline: datetime, pred,
-                    auto_picked: bool = False, auto_picked_from_queue: bool = False) -> None:
+                    auto_picked: bool = False, auto_picked_from_queue: bool = False,
+                    player_name: str = None) -> None:
     """
     Notify a manager it's their turn to pick.
     - Normal turn: SMS fires after 2 min if they haven't opened the app
@@ -580,13 +584,15 @@ def _notify_manager(user_id: int, league_id: int, pick_number: int, deadline: da
         except Exception:
             pass
 
+        player_str = f" — {player_name}" if player_name else ""
+
         if auto_picked_from_queue:
             title = f"🏒 Picked from your queue!{league_name}"
-            body = f"Pick #{pick_number} was made automatically from your priority queue. Check your roster."
+            body = f"Pick #{pick_number} from your queue{player_str}."
             delay = 0  # immediate
         elif auto_picked:
             title = f"🏒 Auto-picked for you!{league_name}"
-            body = f"Pick #{pick_number} was made automatically (you missed your turn). Check your roster."
+            body = f"Pick #{pick_number} — top available player{player_str}."
             delay = 0  # immediate — they need to know
         else:
             title = f"🏒 Your Pick!{league_name}"

--- a/app/services/fantasy_pool_service.py
+++ b/app/services/fantasy_pool_service.py
@@ -41,8 +41,13 @@ def get_player_pool(level_id: int, org_id: int = 1, league_id: int = None, seaso
         )
 
     if season_id is None:
-        # Walk seasons newest-first; skip seasons with zero completed games
-        # (new season just created, no stats yet → use previous season for pool/sizing)
+        # Smart season resolution:
+        # 1. Get the two most recent seasons with any divisions at this level
+        # 2. Count completed (Final) games for each
+        # 3. If the previous season has >= 2x more completed games than the latest,
+        #    use the previous one (latest season just started, sparse stats)
+        # 4. Otherwise use the latest season with any completed games
+        # 5. Fall back to newest season if none have games
         from hockey_blast_common_lib.models import Game
         candidate_seasons = hb.execute(
             select(Division.season_id)
@@ -52,28 +57,42 @@ def get_player_pool(level_id: int, org_id: int = 1, league_id: int = None, seaso
         ).scalars().all()
 
         FINAL_STATUSES = ('Final', 'Final.', 'Final/OT', 'Final/OT2', 'Final/SO', 'Final(SO)')
-        for candidate_sid in candidate_seasons:
+
+        def _completed_games(sid):
             div_ids = hb.execute(
                 select(Division.id).where(
                     Division.level_id == level_id,
                     Division.org_id == org_id,
-                    Division.season_id == candidate_sid,
+                    Division.season_id == sid,
                 )
             ).scalars().all()
             if not div_ids:
-                continue
-            completed = hb.execute(
+                return 0
+            return hb.execute(
                 select(func.count(Game.id)).where(
                     Game.division_id.in_(div_ids),
                     Game.status.in_(FINAL_STATUSES),
                 )
             ).scalar() or 0
-            if completed > 0:
-                season_id = candidate_sid
-                break
-        # If every season has 0 games (brand new level), fall back to latest
-        if season_id is None:
-            season_id = candidate_seasons[0] if candidate_seasons else None
+
+        if len(candidate_seasons) >= 2:
+            latest_sid = candidate_seasons[0]
+            prev_sid = candidate_seasons[1]
+            latest_games = _completed_games(latest_sid)
+            prev_games = _completed_games(prev_sid)
+            # If previous season is 2x richer in completed games, use it
+            if prev_games >= 2 * max(latest_games, 1):
+                season_id = prev_sid
+            elif latest_games > 0:
+                season_id = latest_sid
+            elif prev_games > 0:
+                season_id = prev_sid
+            else:
+                season_id = latest_sid  # neither has games, use latest
+        elif candidate_seasons:
+            # Only one season — use it regardless
+            season_id = candidate_seasons[0]
+        # season_id stays None if no candidates at all
 
     # Resolve season name for display
     _resolved_season_name = None

--- a/app/services/fantasy_pool_service.py
+++ b/app/services/fantasy_pool_service.py
@@ -75,6 +75,14 @@ def get_player_pool(level_id: int, org_id: int = 1, league_id: int = None, seaso
         if season_id is None:
             season_id = candidate_seasons[0] if candidate_seasons else None
 
+    # Resolve season name for display
+    _resolved_season_name = None
+    if season_id is not None:
+        from hockey_blast_common_lib.models import Season as _Season
+        _season_obj = hb.execute(select(_Season).where(_Season.id == season_id)).scalar_one_or_none()
+        if _season_obj:
+            _resolved_season_name = getattr(_season_obj, 'season_name', None) or f"Season {season_id}"
+
     div_ids_stmt = select(Division.id).where(
         Division.level_id == level_id,
         Division.org_id == org_id,
@@ -248,4 +256,5 @@ def get_player_pool(level_id: int, org_id: int = 1, league_id: int = None, seaso
         "roster_skaters": roster_skaters,
         "max_managers": max_managers,
         "resolved_season_id": season_id,
+        "resolved_season_name": _resolved_season_name,
     }

--- a/frontend/src/views/AdminView.vue
+++ b/frontend/src/views/AdminView.vue
@@ -822,6 +822,24 @@ function nextWeekday(dayOfWeek, hour, minute) {
 const launchStartDate = ref(nextWeekday(1, 0, 1))    // next Monday 00:01
 const launchDraftOpens = ref(nextWeekday(6, 16, 0))  // next Saturday 16:00
 const launchDraftCloses = ref(nextWeekday(1, 23, 0)) // next Monday 23:00
+
+function addMinutes(dtLocalStr, mins) {
+  if (!dtLocalStr) return ''
+  const d = new Date(dtLocalStr)
+  d.setMinutes(d.getMinutes() + mins)
+  const pad = n => String(n).padStart(2, '0')
+  return `${d.getFullYear()}-${pad(d.getMonth()+1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`
+}
+
+// Launch form: auto-set closes = opens+30min, season_start = closes+30min
+watch(launchDraftOpens, (val) => {
+  if (val) launchDraftCloses.value = addMinutes(val, 30)
+})
+watch(launchDraftCloses, (val) => {
+  if (val) launchStartDate.value = addMinutes(val, 30)
+})
+
+
 const nowLocal = computed(() => {
   const d = new Date(); const pad = n => String(n).padStart(2, '0')
   return `${d.getFullYear()}-${pad(d.getMonth()+1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`
@@ -848,6 +866,14 @@ const leagueEditForm = ref({ season_label: '', season_starts_at: '', draft_opens
 const hbSeasons = ref([])
 const leagueEditSaving = ref(false)
 const leagueEditError = ref(null)
+
+// Edit form: auto-cascade opens→closes+30min→season_starts+30min
+watch(() => leagueEditForm.value.draft_opens_at, (val) => {
+  if (val) leagueEditForm.value.draft_closes_at = addMinutes(val, 30)
+})
+watch(() => leagueEditForm.value.draft_closes_at, (val) => {
+  if (val) leagueEditForm.value.season_starts_at = addMinutes(val, 30)
+})
 
 function toLocalDtInput(isoStr) {
   if (!isoStr) return ''

--- a/frontend/src/views/FantasyLeagueView.vue
+++ b/frontend/src/views/FantasyLeagueView.vue
@@ -1140,11 +1140,22 @@ watch(activeTab, (tab) => {
 })
 
 // Auto-switch pool tab based on pick type
-watch(currentPick, (pick) => {
+// Also trigger queue auto-pick if it's our turn and we have a queue
+watch(currentPick, async (pick) => {
   if (!pick || pick.user_id !== myUserId.value) return
   if (pick.is_goalie_pick) poolTab.value = 'goalies'
   else if (pick.is_ref_pick) poolTab.value = 'refs'
   else poolTab.value = 'skaters'
+
+  // If we have a queue, ask the backend to auto-pick from it immediately
+  if (myPriorityQueue.value.length > 0) {
+    try {
+      const { data } = await api.post(`/api/fantasy/leagues/${route.params.id}/draft/process-queue`)
+      if (data.picked) {
+        await Promise.all([loadDraftQueue(), loadPool(), loadMyQueue(), loadLeague()])
+      }
+    } catch { /* ignore — manual pick still works */ }
+  }
 }, { immediate: true })
 
 onMounted(async () => {
@@ -1168,8 +1179,9 @@ onMounted(async () => {
     joinForm.value.join_code = String(urlCode).toUpperCase()
     showJoinModal.value = true
   }
+  loadMyQueue()  // always load queue — independent of league status / auth timing
   if (league.value && !['forming'].includes(league.value.status)) {
-    await Promise.all([loadDraftQueue(), loadPool(), loadMyQueue()])
+    await Promise.all([loadDraftQueue(), loadPool()])
   }
 })
 </script>

--- a/frontend/src/views/FantasyLeagueView.vue
+++ b/frontend/src/views/FantasyLeagueView.vue
@@ -1128,11 +1128,11 @@ onUnmounted(() => { if (_draftPollInterval) clearInterval(_draftPollInterval) })
 
 watch(() => league.value?.status, (status) => {
   if (_draftPollInterval) { clearInterval(_draftPollInterval); _draftPollInterval = null }
-  if (['draft_open', 'drafting'].includes(status)) {
+  if (['forming', 'draft_open', 'drafting'].includes(status)) {
     _draftPollInterval = setInterval(async () => {
       await loadLeague()
       await Promise.all([loadDraftQueue(), loadPool(), loadMyQueue()])
-    }, 30000)
+    }, 10000)  // 10s — fast enough to catch auto-picks cascading
   }
 }, { immediate: true })
 

--- a/frontend/src/views/FantasyLeagueView.vue
+++ b/frontend/src/views/FantasyLeagueView.vue
@@ -653,12 +653,12 @@ const RosterList = {
       // Table header
       const thead = h('thead', [
         h('tr', [
-          h('th', { class: 'text-left text-xs font-medium opacity-60 pb-1 pr-4' }, 'Player'),
-          h('th', { class: 'text-right text-xs font-medium opacity-60 pb-1 px-2' }, 'GP'),
-          h('th', { class: 'text-right text-xs font-medium opacity-60 pb-1 px-2' }, 'G'),
-          h('th', { class: 'text-right text-xs font-medium opacity-60 pb-1 px-2' }, 'A'),
-          h('th', { class: 'text-right text-xs font-medium opacity-60 pb-1 px-2 text-error' }, 'PIM'),
-          h('th', { class: 'text-right text-xs font-medium opacity-60 pb-1 pl-2' }, 'FP'),
+          h('th', { class: 'text-left text-xs font-medium opacity-60 pb-1 w-full' }, 'Player'),
+          h('th', { class: 'text-right text-xs font-medium opacity-60 pb-1 px-3 whitespace-nowrap' }, 'GP'),
+          h('th', { class: 'text-right text-xs font-medium opacity-60 pb-1 px-3 whitespace-nowrap' }, 'G'),
+          h('th', { class: 'text-right text-xs font-medium opacity-60 pb-1 px-3 whitespace-nowrap' }, 'A'),
+          h('th', { class: 'text-right text-xs font-medium opacity-60 pb-1 px-3 whitespace-nowrap text-error' }, 'PIM'),
+          h('th', { class: 'text-right text-xs font-medium opacity-60 pb-1 pl-3 whitespace-nowrap' }, 'FP'),
         ])
       ])
 
@@ -682,11 +682,11 @@ const RosterList = {
         ])
         return h('tr', { key: p.hb_human_id, class: 'border-t border-base-300/30' }, [
           nameCell,
-          h('td', { class: 'text-right text-xs px-2 py-1 opacity-70' }, p.gp ?? 0),
-          h('td', { class: 'text-right text-xs px-2 py-1 opacity-70' }, p.goals ?? 0),
-          h('td', { class: 'text-right text-xs px-2 py-1 opacity-70' }, p.assists ?? 0),
-          h('td', { class: 'text-right text-xs px-2 py-1 ' + (p.penalties ? 'text-error' : 'opacity-70') }, p.penalties ?? 0),
-          h('td', { class: 'text-right text-xs pl-2 py-1 font-semibold text-primary' },
+          h('td', { class: 'text-right text-xs px-3 py-1 opacity-70 whitespace-nowrap' }, p.gp ?? 0),
+          h('td', { class: 'text-right text-xs px-3 py-1 opacity-70 whitespace-nowrap' }, p.goals ?? 0),
+          h('td', { class: 'text-right text-xs px-3 py-1 opacity-70 whitespace-nowrap' }, p.assists ?? 0),
+          h('td', { class: 'text-right text-xs px-3 py-1 whitespace-nowrap ' + (p.penalties ? 'text-error' : 'opacity-70') }, p.penalties ?? 0),
+          h('td', { class: 'text-right text-xs pl-3 py-1 font-semibold text-primary whitespace-nowrap' },
             p.fantasy_points != null ? p.fantasy_points.toFixed(1) : '—'),
         ])
       })

--- a/frontend/src/views/FantasyLeagueView.vue
+++ b/frontend/src/views/FantasyLeagueView.vue
@@ -135,7 +135,7 @@
           </div>
 
           <!-- My Priority Queue strip -->
-          <div v-if="['draft_open', 'drafting'].includes(league.status) && league.is_member && isAuthenticated && myPriorityQueue.length > 0" class="mb-4">
+          <div v-if="['forming', 'draft_open', 'drafting'].includes(league.status) && league.is_member && isAuthenticated && myPriorityQueue.length > 0" class="mb-4">
             <div class="card bg-warning/10 border border-warning/30 shadow">
               <div class="card-body p-3">
                 <div class="flex items-center gap-2 flex-wrap">
@@ -158,13 +158,13 @@
             </div>
           </div>
 
-          <!-- Player pool panel (shown during draft, full pool with drafted indicators) -->
-          <div v-if="['draft_open', 'drafting'].includes(league.status)" class="mb-6">
+          <!-- Player pool panel (shown during forming for queue building, and during draft) -->
+          <div v-if="['forming', 'draft_open', 'drafting'].includes(league.status) && league.is_member" class="mb-6">
             <div class="card bg-base-200 shadow">
               <div class="card-body p-4">
                 <div class="flex items-center justify-between mb-3 flex-wrap gap-2">
                   <h3 class="font-semibold flex items-center flex-wrap gap-2">
-                    Draft Pool
+                    {{ league.status === 'forming' ? 'Build Your Queue' : 'Draft Pool' }}
                     <span v-if="currentPick && currentPick.user_id === myUserId && league.is_member" class="badge badge-success badge-sm animate-pulse">Your Pick!</span>
                     <template v-if="league.is_member">
                       <span class="text-xs font-normal text-base-content/50 flex items-center gap-1">
@@ -1190,7 +1190,7 @@ onMounted(async () => {
     showJoinModal.value = true
   }
   loadMyQueue()  // always load queue — independent of league status / auth timing
-  if (league.value && !['forming'].includes(league.value.status)) {
+  if (league.value && ['forming', 'draft_open', 'drafting'].includes(league.value.status)) {
     await Promise.all([loadDraftQueue(), loadPool()])
   }
 })

--- a/frontend/src/views/FantasyLeagueView.vue
+++ b/frontend/src/views/FantasyLeagueView.vue
@@ -143,7 +143,7 @@
                   <div class="flex flex-wrap gap-1">
                     <template v-for="(hid, idx) in myPriorityQueue" :key="hid">
                       <span class="badge badge-sm gap-1"
-                        :class="idx === 0 ? 'badge-warning' : 'badge-ghost'"
+                        :class="draftQueue.find(p => p.hb_human_id === hid && p.picked_at) ? 'badge-ghost opacity-40 line-through' : idx === 0 ? 'badge-warning' : 'badge-ghost'"
                       >
                         <span class="font-bold">{{ idx + 1 }}.</span>
                         {{ [...pool.skaters, ...pool.goalies, ...(pool.refs||[])].find(p => p.hb_human_id === hid)?.first_name }}
@@ -1101,9 +1101,7 @@ async function pickPlayer(player) {
   picking.value = true
   try {
     await api.post(`/api/fantasy/leagues/${route.params.id}/draft`, { hb_human_id: player.hb_human_id })
-    await loadDraftQueue()
-    await loadPool()
-    await loadLeague()
+    await Promise.all([loadDraftQueue(), loadPool(), loadMyQueue(), loadLeague()])
   } catch (e) {
     pickError.value = e?.response?.data?.message || 'Failed to pick player'
   } finally {
@@ -1126,7 +1124,7 @@ watch(() => league.value?.status, (status) => {
   if (['draft_open', 'drafting'].includes(status)) {
     _draftPollInterval = setInterval(async () => {
       await loadLeague()
-      await Promise.all([loadDraftQueue(), loadPool()])
+      await Promise.all([loadDraftQueue(), loadPool(), loadMyQueue()])
     }, 30000)
   }
 }, { immediate: true })

--- a/frontend/src/views/FantasyLeagueView.vue
+++ b/frontend/src/views/FantasyLeagueView.vue
@@ -820,10 +820,20 @@ const queuePositionOf = (hb_human_id) => {
   return idx === -1 ? null : idx + 1
 }
 
-function toggleQueuePlayer(hb_human_id) {
+async function toggleQueuePlayer(hb_human_id) {
+  // If it's our turn, ☆ = instant draft (Option A)
+  if (currentPick.value && currentPick.value.user_id === myUserId.value && league.value?.is_member) {
+    const player = [...(pool.value.skaters || []), ...(pool.value.goalies || []), ...(pool.value.refs || [])]
+      .find(p => p.hb_human_id === hb_human_id)
+    if (player) {
+      await pickPlayer(player)
+      return
+    }
+  }
+  // Otherwise manage queue as normal
   const idx = myPriorityQueue.value.indexOf(hb_human_id)
   if (idx === -1) {
-    // Not in queue → add to end (lowest priority)
+    // Not in queue → add to end
     myPriorityQueue.value = [...myPriorityQueue.value, hb_human_id]
   } else if (idx === 0) {
     // Already at top → remove

--- a/frontend/src/views/FantasyLeagueView.vue
+++ b/frontend/src/views/FantasyLeagueView.vue
@@ -101,19 +101,19 @@
 
       <!-- ── Draft Tab ── -->
       <div v-if="activeTab === 'draft'">
-        <div v-if="league.status === 'forming'" class="text-center py-10 text-base-content/40">
+        <!-- Forming status banner -->
+        <div v-if="league.status === 'forming'" class="text-center py-6 text-base-content/40 mb-4">
           <div class="text-4xl mb-2">⏳</div>
           <p class="font-medium">Draft opens {{ formatDeadline(league.draft_opens_at) }}</p>
           <p class="text-sm mt-1 max-w-xs mx-auto">
-            The draft will start automatically once the league fills up, or at the scheduled time — whichever comes first.
+            {{ league.is_member ? 'Use this time to star players and build your queue below!' : 'The draft starts at the scheduled time once enough managers join.' }}
           </p>
-          <p v-if="league.is_member" class="mt-3 text-success text-sm">✅ You're in! You'll be notified when it's your turn to pick.</p>
-          <p v-else class="mt-3">
+          <p v-if="!league.is_member" class="mt-3">
             <button class="btn btn-primary btn-sm" @click="isAuthenticated ? showJoinModal = true : requireLogin()">Join League</button>
           </p>
         </div>
 
-        <div v-else>
+        <div>
           <!-- Current pick info -->
           <div v-if="currentPick" class="alert mb-4" :class="currentPick.user_id === myUserId ? 'alert-success' : 'alert-info'">
             <div>

--- a/frontend/src/views/FantasyLeagueView.vue
+++ b/frontend/src/views/FantasyLeagueView.vue
@@ -1167,7 +1167,7 @@ onMounted(async () => {
     showJoinModal.value = true
   }
   if (league.value && !['forming'].includes(league.value.status)) {
-    await Promise.all([loadDraftQueue(), loadPool()])
+    await Promise.all([loadDraftQueue(), loadPool(), loadMyQueue()])
   }
 })
 </script>

--- a/frontend/src/views/FantasyLeagueView.vue
+++ b/frontend/src/views/FantasyLeagueView.vue
@@ -1147,7 +1147,7 @@ watch(() => league.value?.status, (status) => {
       // Poll silently — don't show spinner or reset scroll position
       await loadLeague({ silent: true })
       await Promise.all([loadDraftQueue(), loadPoolSilent(), loadMyQueue()])
-    }, 10000)  // 10s — fast enough to catch auto-picks cascading
+    }, 30000)  // 30s — background silent poll, no spinner/scroll jump
   }
 }, { immediate: true })
 

--- a/frontend/src/views/FantasyLeagueView.vue
+++ b/frontend/src/views/FantasyLeagueView.vue
@@ -155,14 +155,16 @@
               <div class="card-body p-4">
                 <div class="flex items-center justify-between mb-3 flex-wrap gap-2">
                   <h3 class="font-semibold flex items-center flex-wrap gap-2">
-                    {{ league.status === 'forming' ? 'Build Your Queue' : 'Draft Pool' }}
+                    <span v-if="league.status === 'forming'">Queue up now — skip the live draft</span>
+                    <span v-else>Draft Pool</span>
                     <span v-if="currentPick && currentPick.user_id === myUserId && league.is_member" class="badge badge-success badge-sm animate-pulse">Your Pick!</span>
                     <template v-if="league.is_member">
-                      <span class="text-xs font-semibold text-base-content/80 flex items-center gap-1.5 bg-base-300 px-2 py-0.5 rounded-full">
-                        <span title="Skaters still needed">🏒 {{ Math.max(0, league.roster_skaters - myDraftedSkaters) }}</span>
-                        <span title="Goalies still needed">🥅 {{ Math.max(0, league.roster_goalies - myDraftedGoalies) }}</span>
-                        <span v-if="league.roster_refs > 0" title="Refs still needed">🎮 {{ Math.max(0, league.roster_refs - myDraftedRefs) }}</span>
-                        <span class="text-base-content/60">needed</span>
+                      <span class="flex items-center gap-2 text-sm font-bold">
+                        <span class="text-base-content/40 font-normal text-xs">Roster:</span>
+                        <span title="Skaters" class="flex items-center gap-0.5">🏒 <span class="text-base text-primary">{{ Math.max(0, league.roster_skaters - myDraftedSkaters) }}</span></span>
+                        <span title="Goalies" class="flex items-center gap-0.5">🥅 <span class="text-base text-primary">{{ Math.max(0, league.roster_goalies - myDraftedGoalies) }}</span></span>
+                        <span v-if="league.roster_refs > 0" title="Refs" class="flex items-center gap-0.5">🎮 <span class="text-base text-primary">{{ Math.max(0, league.roster_refs - myDraftedRefs) }}</span></span>
+                        <span class="text-base-content/40 font-normal text-xs">needed</span>
                       </span>
                     </template>
                   </h3>

--- a/frontend/src/views/FantasyLeagueView.vue
+++ b/frontend/src/views/FantasyLeagueView.vue
@@ -1112,7 +1112,10 @@ async function pickPlayer(player) {
 // Load standings when tab changes
 // Reload league when auth state resolves — token wasn't available on first load
 watch(authLoading, (loading) => {
-  if (!loading) loadLeague()
+  if (!loading) {
+    loadLeague()
+    loadMyQueue()
+  }
 })
 
 // Auto-refresh draft state every 30s when draft is active

--- a/frontend/src/views/FantasyLeagueView.vue
+++ b/frontend/src/views/FantasyLeagueView.vue
@@ -193,7 +193,7 @@
                 </div>
 
                 <!-- Skaters table -->
-                <div v-if="poolTab === 'skaters'" class="overflow-x-auto max-h-80 overflow-y-auto">
+                <div v-if="poolTab === 'skaters'" class="overflow-x-auto max-h-80 overflow-y-auto pool-scroll-container">
                   <table class="table table-xs w-full">
                     <thead class="sticky top-0 bg-base-200 z-10">
                       <tr>
@@ -256,7 +256,7 @@
                 </div>
 
                 <!-- Goalies table -->
-                <div v-if="poolTab === 'goalies'" class="overflow-x-auto max-h-80 overflow-y-auto">
+                <div v-if="poolTab === 'goalies'" class="overflow-x-auto max-h-80 overflow-y-auto pool-scroll-container">
                   <table class="table table-xs w-full">
                     <thead class="sticky top-0 bg-base-200 z-10">
                       <tr>
@@ -315,7 +315,7 @@
                 </div>
 
                 <!-- Refs table -->
-                <div v-if="poolTab === 'refs'" class="overflow-x-auto max-h-80 overflow-y-auto">
+                <div v-if="poolTab === 'refs'" class="overflow-x-auto max-h-80 overflow-y-auto pool-scroll-container">
                   <table class="table table-xs w-full">
                     <thead class="sticky top-0 bg-base-200 z-10">
                       <tr>
@@ -611,7 +611,7 @@
 </template>
 
 <script setup>
-import { ref, computed, onMounted, onUnmounted, watch, h } from 'vue'
+import { ref, computed, onMounted, onUnmounted, watch, h, nextTick } from 'vue'
 import { useRoute } from 'vue-router'
 import { useAuth0 } from '@auth0/auth0-vue'
 import { useUserStore } from '@/stores/user'
@@ -998,15 +998,15 @@ function requireLogin() {
   loginWithRedirect()
 }
 
-async function loadLeague() {
-  loading.value = true
+async function loadLeague({ silent = false } = {}) {
+  if (!silent) loading.value = true
   try {
     const { data } = await api.get(`/api/fantasy/leagues/${route.params.id}`)
     league.value = data
   } catch {
-    league.value = null
+    if (!silent) league.value = null
   } finally {
-    loading.value = false
+    if (!silent) loading.value = false
   }
 }
 
@@ -1025,6 +1025,20 @@ async function loadPool() {
     pool.value = data
   } catch {
     pool.value = { skaters: [], goalies: [] }
+  }
+}
+
+async function loadPoolSilent() {
+  // Reload pool without disrupting scroll position
+  try {
+    const el = document.querySelector('.pool-scroll-container')
+    const scrollTop = el ? el.scrollTop : 0
+    const { data } = await api.get(`/api/fantasy/leagues/${route.params.id}/pool`)
+    pool.value = data
+    await nextTick()
+    if (el) el.scrollTop = scrollTop
+  } catch {
+    // silently ignore on background poll
   }
 }
 
@@ -1130,8 +1144,9 @@ watch(() => league.value?.status, (status) => {
   if (_draftPollInterval) { clearInterval(_draftPollInterval); _draftPollInterval = null }
   if (['forming', 'draft_open', 'drafting'].includes(status)) {
     _draftPollInterval = setInterval(async () => {
-      await loadLeague()
-      await Promise.all([loadDraftQueue(), loadPool(), loadMyQueue()])
+      // Poll silently — don't show spinner or reset scroll position
+      await loadLeague({ silent: true })
+      await Promise.all([loadDraftQueue(), loadPoolSilent(), loadMyQueue()])
     }, 10000)  // 10s — fast enough to catch auto-picks cascading
   }
 }, { immediate: true })

--- a/frontend/src/views/FantasyLeagueView.vue
+++ b/frontend/src/views/FantasyLeagueView.vue
@@ -58,16 +58,7 @@
             >
               Join League
             </button>
-            <!-- Open draft -->
-            <button
-              v-if="league.is_creator && league.status === 'forming' && (league.manager_count || 0) >= 2"
-              class="btn btn-warning btn-sm"
-              :disabled="openingDraft"
-              @click="openDraft"
-            >
-              <span v-if="openingDraft" class="loading loading-spinner loading-xs"></span>
-              Open Draft
-            </button>
+            <!-- Open draft button removed: draft opens automatically at scheduled time -->
             
           </div>
         </div>

--- a/frontend/src/views/FantasyLeagueView.vue
+++ b/frontend/src/views/FantasyLeagueView.vue
@@ -158,11 +158,11 @@
                     {{ league.status === 'forming' ? 'Build Your Queue' : 'Draft Pool' }}
                     <span v-if="currentPick && currentPick.user_id === myUserId && league.is_member" class="badge badge-success badge-sm animate-pulse">Your Pick!</span>
                     <template v-if="league.is_member">
-                      <span class="text-xs font-normal text-base-content/50 flex items-center gap-1">
+                      <span class="text-xs font-semibold text-base-content/80 flex items-center gap-1.5 bg-base-300 px-2 py-0.5 rounded-full">
                         <span title="Skaters still needed">🏒 {{ Math.max(0, league.roster_skaters - myDraftedSkaters) }}</span>
                         <span title="Goalies still needed">🥅 {{ Math.max(0, league.roster_goalies - myDraftedGoalies) }}</span>
                         <span v-if="league.roster_refs > 0" title="Refs still needed">🎮 {{ Math.max(0, league.roster_refs - myDraftedRefs) }}</span>
-                        <span class="text-base-content/30">needed</span>
+                        <span class="text-base-content/60">needed</span>
                       </span>
                     </template>
                   </h3>

--- a/frontend/src/views/FantasyLeagueView.vue
+++ b/frontend/src/views/FantasyLeagueView.vue
@@ -163,9 +163,17 @@
             <div class="card bg-base-200 shadow">
               <div class="card-body p-4">
                 <div class="flex items-center justify-between mb-3 flex-wrap gap-2">
-                  <h3 class="font-semibold">
+                  <h3 class="font-semibold flex items-center flex-wrap gap-2">
                     Draft Pool
-                    <span v-if="currentPick && currentPick.user_id === myUserId && league.is_member" class="badge badge-success badge-sm ml-2 animate-pulse">Your Pick!</span>
+                    <span v-if="currentPick && currentPick.user_id === myUserId && league.is_member" class="badge badge-success badge-sm animate-pulse">Your Pick!</span>
+                    <template v-if="league.is_member">
+                      <span class="text-xs font-normal text-base-content/50 flex items-center gap-1">
+                        <span title="Skaters still needed">🏒 {{ Math.max(0, league.roster_skaters - myDraftedSkaters) }}</span>
+                        <span title="Goalies still needed">🥅 {{ Math.max(0, league.roster_goalies - myDraftedGoalies) }}</span>
+                        <span v-if="league.roster_refs > 0" title="Refs still needed">🎮 {{ Math.max(0, league.roster_refs - myDraftedRefs) }}</span>
+                        <span class="text-base-content/30">needed</span>
+                      </span>
+                    </template>
                   </h3>
                   <input
                     v-model="playerFilter"

--- a/frontend/src/views/FantasyLeagueView.vue
+++ b/frontend/src/views/FantasyLeagueView.vue
@@ -1117,7 +1117,7 @@ watch(authLoading, (loading) => {
 
 watch(isAuthenticated, (authed) => {
   if (authed) loadMyQueue()
-})
+}, { immediate: true })
 
 // Auto-refresh draft state every 30s when draft is active
 let _draftPollInterval = null

--- a/frontend/src/views/FantasyLeagueView.vue
+++ b/frontend/src/views/FantasyLeagueView.vue
@@ -844,11 +844,11 @@ function scheduleSaveQueue() {
 }
 
 async function loadMyQueue() {
-  if (!isAuthenticated.value) return
   try {
     const { data } = await api.get(`/api/fantasy/leagues/${route.params.id}/draft/my-queue`)
     myPriorityQueue.value = (data.queue || []).map(i => i.hb_human_id)
   } catch {
+    // 401 if not authenticated — silently leave queue empty
     myPriorityQueue.value = []
   }
 }
@@ -1112,10 +1112,11 @@ async function pickPlayer(player) {
 // Load standings when tab changes
 // Reload league when auth state resolves — token wasn't available on first load
 watch(authLoading, (loading) => {
-  if (!loading) {
-    loadLeague()
-    loadMyQueue()
-  }
+  if (!loading) loadLeague()
+})
+
+watch(isAuthenticated, (authed) => {
+  if (authed) loadMyQueue()
 })
 
 // Auto-refresh draft state every 30s when draft is active

--- a/frontend/src/views/FantasyView.vue
+++ b/frontend/src/views/FantasyView.vue
@@ -256,7 +256,7 @@
 </template>
 
 <script setup>
-import { ref, computed, onMounted } from 'vue'
+import { ref, computed, onMounted, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import { useApiClient } from '@/api/client'
 import { useAuth0 } from '@auth0/auth0-vue'
@@ -292,6 +292,22 @@ const createdJoinCode = ref('')
 const showJoinCodeModal = ref(false)
 const showJoinCodeEntry = ref(false)
 const joinCodeEntry = ref('')
+
+function addMins(dtStr, mins) {
+  if (!dtStr) return ''
+  const d = new Date(dtStr)
+  d.setMinutes(d.getMinutes() + mins)
+  const pad = n => String(n).padStart(2, '0')
+  return `${d.getFullYear()}-${pad(d.getMonth()+1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`
+}
+
+// Auto-cascade: draft opens → closes +30min → season start +30min
+watch(() => createForm.value.draft_opens_at, (val) => {
+  if (val) createForm.value.draft_closes_at = addMins(val, 30)
+})
+watch(() => createForm.value.draft_closes_at, (val) => {
+  if (val) createForm.value.season_starts_at = addMins(val, 30)
+})
 const joinCodeError = ref('')
 
 // League + level selectors

--- a/frontend/src/views/FantasyView.vue
+++ b/frontend/src/views/FantasyView.vue
@@ -170,6 +170,17 @@
             </select>
           </div>
 
+          <!-- Season used for player pool (shown after level selected) -->
+          <div v-if="createForm.level_id && poolSeasonName" class="form-control">
+            <label class="label py-1">
+              <span class="label-text text-sm text-base-content/50">Player pool from</span>
+            </label>
+            <div class="flex items-center gap-2 px-1">
+              <span class="text-sm font-semibold">📅 {{ poolSeasonName }}</span>
+              <span class="text-xs text-base-content/40">(most recent season with games)</span>
+            </div>
+          </div>
+
           <!-- Max managers (shown after level selected, capped by pool) -->
           <div v-if="createForm.level_id" class="form-control">
             <label class="label py-1">
@@ -318,6 +329,7 @@ const levelsLoading = ref(false)
 
 // Pool info (max managers cap)
 const poolMaxManagers = ref(null)
+const poolSeasonName = ref(null)
 const poolLoading = ref(false)
 
 const managerOptions = computed(() => {
@@ -411,7 +423,7 @@ async function loadLevels(leagueId) {
 }
 
 async function loadPoolInfo(levelId, hbLeagueId) {
-  poolMaxManagers.value = null
+  poolMaxManagers.value = null; poolSeasonName.value = null
   createForm.value.max_managers = null
   if (!levelId) return
   poolLoading.value = true
@@ -420,6 +432,7 @@ async function loadPoolInfo(levelId, hbLeagueId) {
       params: { level_id: levelId, hb_league_id: hbLeagueId, org_id: 1 }
     })
     poolMaxManagers.value = data.max_managers || 12
+    poolSeasonName.value = data.resolved_season_name || null
     // Default to max
     createForm.value.max_managers = poolMaxManagers.value
   } catch {
@@ -434,7 +447,7 @@ async function openCreateModal() {
   createModalKey.value++
   showCreateModal.value = true
   createError.value = ''
-  poolMaxManagers.value = null
+  poolMaxManagers.value = null; poolSeasonName.value = null
   createForm.value = {
     hb_league_id: null,
     level_id: null,
@@ -455,7 +468,7 @@ async function openCreateModal() {
 function onLeagueChange() {
   createForm.value.level_id = null
   createForm.value.max_managers = null
-  poolMaxManagers.value = null
+  poolMaxManagers.value = null; poolSeasonName.value = null
   loadLevels(createForm.value.hb_league_id)
 }
 

--- a/frontend/src/views/MyFantasyView.vue
+++ b/frontend/src/views/MyFantasyView.vue
@@ -101,7 +101,7 @@ const api = useApiClient()
 const leagues = ref([])
 const loading = ref(true)
 
-const STATUS_ORDER = ['active', 'drafting', 'draft_open', 'forming', 'completed']
+const STATUS_ORDER = ['forming', 'draft_open', 'drafting', 'active', 'completed']
 const STATUS_LABELS = {
   forming: 'Forming',
   draft_open: 'Draft Open',

--- a/gunicorn_config.py
+++ b/gunicorn_config.py
@@ -7,13 +7,6 @@ timeout = 120
 accesslog = "-"
 errorlog = "-"
 loglevel = "info"
-preload_app = True  # load app in master before forking — required for APScheduler
-
-def post_fork(server, worker):
-    """Shut down the scheduler in worker processes — it only runs in the master."""
-    try:
-        from app.jobs.grade_results import _scheduler
-        if _scheduler is not None and _scheduler.running:
-            _scheduler.shutdown(wait=False)
-    except Exception:
-        pass
+# Scheduler runs in each worker independently (simpler than preload_app + post_fork).
+# APScheduler with IntervalTrigger is idempotent — multiple workers checking is fine.
+workers = 1  # single worker to avoid duplicate scheduler jobs

--- a/gunicorn_config.py
+++ b/gunicorn_config.py
@@ -7,3 +7,13 @@ timeout = 120
 accesslog = "-"
 errorlog = "-"
 loglevel = "info"
+preload_app = True  # load app in master before forking — required for APScheduler
+
+def post_fork(server, worker):
+    """Shut down the scheduler in worker processes — it only runs in the master."""
+    try:
+        from app.jobs.grade_results import _scheduler
+        if _scheduler is not None and _scheduler.running:
+            _scheduler.shutdown(wait=False)
+    except Exception:
+        pass

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "hockey-blast-sportsbook",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "hockey-blast-sportsbook",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}


### PR DESCRIPTION
## Summary

Full drafting overhaul — per-manager priority queues, auto-pick, and a polished draft UX.

### What's in this branch

**Priority Queue System**
- Per-manager draft queue (star players to queue them)
- Auto-pick from queue when it's your turn
- Queue syncs and persists across sessions
- Auto-pick notifications include player name

**Draft Flow**
- Pool visible during `forming` so managers can pre-build queues before draft opens
- Scheduler auto-opens draft at `draft_opens_at` time (no manual Open Draft button)
- Wait for `draft_opens_at` when league fills
- Needed counts pill in Draft Pool header (bold, standout)
- Forming leagues sorted first in My Leagues view

**UX / Polish**
- Silent background poll every 30s — no spinner, no scroll jumps (scroll position preserved)
- Queue header with better copy + bigger roster numbers
- Separate `draft_season_id` from `hb_season_id` (play season)
- Smarter season resolution (uses prev season if 2x+ more completed games)
- Auto-cascade times in create league form

**Bug Fixes**
- Delete `FantasyManagerQueue` before league in both single and batch delete
- Fixed scheduler not starting under gunicorn
- Fixed queue loading on hard reload / auth resolve