### PR TITLE
feat: smart draft date presets based on last game in season

### DIFF
--- a/app/blueprints/fantasy.py
+++ b/app/blueprints/fantasy.py
@@ -234,6 +234,7 @@ def get_level_pool():
             "roster_skaters": pool["roster_skaters"],
             "resolved_season_id": pool.get("resolved_season_id"),
             "resolved_season_name": pool.get("resolved_season_name"),
+            "last_game_date": pool.get("last_game_date"),
         })
     except Exception as e:
         return jsonify({"max_managers": 12, "roster_skaters": 8})  # fallback

--- a/app/services/fantasy_pool_service.py
+++ b/app/services/fantasy_pool_service.py
@@ -96,11 +96,29 @@ def get_player_pool(level_id: int, org_id: int = 1, league_id: int = None, seaso
 
     # Resolve season name for display
     _resolved_season_name = None
+    _last_game_date = None
     if season_id is not None:
         from hockey_blast_common_lib.models import Season as _Season
         _season_obj = hb.execute(select(_Season).where(_Season.id == season_id)).scalar_one_or_none()
         if _season_obj:
             _resolved_season_name = getattr(_season_obj, 'season_name', None) or f"Season {season_id}"
+        # Find the latest scheduled game date in this season/level
+        _div_ids_for_date = hb.execute(
+            select(Division.id).where(
+                Division.level_id == level_id,
+                Division.org_id == org_id,
+                Division.season_id == season_id,
+            )
+        ).scalars().all()
+        if _div_ids_for_date:
+            from hockey_blast_common_lib.models import Game as _Game
+            _max_date = hb.execute(
+                select(func.max(_Game.date)).where(
+                    _Game.division_id.in_(_div_ids_for_date)
+                )
+            ).scalar()
+            if _max_date:
+                _last_game_date = _max_date.isoformat() if hasattr(_max_date, 'isoformat') else str(_max_date)
 
     div_ids_stmt = select(Division.id).where(
         Division.level_id == level_id,
@@ -276,4 +294,5 @@ def get_player_pool(level_id: int, org_id: int = 1, league_id: int = None, seaso
         "max_managers": max_managers,
         "resolved_season_id": season_id,
         "resolved_season_name": _resolved_season_name,
+        "last_game_date": _last_game_date,
     }

--- a/frontend/src/views/FantasyView.vue
+++ b/frontend/src/views/FantasyView.vue
@@ -267,7 +267,7 @@
 </template>
 
 <script setup>
-import { ref, computed, onMounted, watch } from 'vue'
+import { ref, computed, onMounted, watch, nextTick } from 'vue'
 import { useRouter } from 'vue-router'
 import { useApiClient } from '@/api/client'
 import { useAuth0 } from '@auth0/auth0-vue'
@@ -304,6 +304,26 @@ const showJoinCodeModal = ref(false)
 const showJoinCodeEntry = ref(false)
 const joinCodeEntry = ref('')
 
+// Given a date (string or Date), find the first Friday at 7PM PT after that date
+function firstFridayAfter(dateStr) {
+  const d = new Date(dateStr + 'T00:00:00')  // treat as local date
+  // Advance past the date itself
+  d.setDate(d.getDate() + 1)
+  // Walk forward until Friday (day 5)
+  while (d.getDay() !== 5) d.setDate(d.getDate() + 1)
+  d.setHours(19, 0, 0, 0)
+  const pad = n => String(n).padStart(2, '0')
+  return `${d.getFullYear()}-${pad(d.getMonth()+1)}-${pad(d.getDate())}T19:00`
+}
+
+function addHours(dtStr, hours) {
+  if (!dtStr) return ''
+  const d = new Date(dtStr)
+  d.setHours(d.getHours() + hours)
+  const pad = n => String(n).padStart(2, '0')
+  return `${d.getFullYear()}-${pad(d.getMonth()+1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`
+}
+
 function addMins(dtStr, mins) {
   if (!dtStr) return ''
   const d = new Date(dtStr)
@@ -312,13 +332,16 @@ function addMins(dtStr, mins) {
   return `${d.getFullYear()}-${pad(d.getMonth()+1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`
 }
 
-// Auto-cascade: draft opens → closes +30min → season start +30min
-watch(() => createForm.value.draft_opens_at, (val) => {
-  if (val) createForm.value.draft_closes_at = addMins(val, 30)
+// Dates are auto-filled by loadPoolInfo based on last game date.
+// Still cascade if user manually changes draft_opens_at so closes/season_start follow.
+watch(() => createForm.value.draft_opens_at, (val, oldVal) => {
+  // Only cascade if this is a manual change (not an auto-fill from level pick)
+  if (val && val !== oldVal && !_autoFillingDates.value) {
+    createForm.value.draft_closes_at = addHours(val, 48)
+    createForm.value.season_starts_at = addHours(createForm.value.draft_closes_at, 6)
+  }
 })
-watch(() => createForm.value.draft_closes_at, (val) => {
-  if (val) createForm.value.season_starts_at = addMins(val, 30)
-})
+const _autoFillingDates = ref(false)
 const joinCodeError = ref('')
 
 // League + level selectors
@@ -433,8 +456,19 @@ async function loadPoolInfo(levelId, hbLeagueId) {
     })
     poolMaxManagers.value = data.max_managers || 12
     poolSeasonName.value = data.resolved_season_name || null
-    // Default to max
     createForm.value.max_managers = poolMaxManagers.value
+    // Auto-fill draft dates based on last game in the season
+    if (data.last_game_date) {
+      const opens = firstFridayAfter(data.last_game_date)  // first Friday 7PM after last game
+      const closes = addHours(opens, 48)                   // +48h
+      const seasonStart = addHours(closes, 6)              // +6h after close
+      _autoFillingDates.value = true
+      createForm.value.draft_opens_at = opens
+      createForm.value.draft_closes_at = closes
+      createForm.value.season_starts_at = seasonStart
+      await nextTick()
+      _autoFillingDates.value = false
+    }
   } catch {
     poolMaxManagers.value = 12
     createForm.value.max_managers = 12


### PR DESCRIPTION
When a level is picked in the create league form, auto-fill draft dates:
- **Draft opens:** first Friday at 7PM after the last scheduled game in the season
- **Draft closes:** +48h after opens
- **Season starts:** +6h after closes

Backend: `last_game_date` now returned from `/api/fantasy/level-pool` (via `get_player_pool`).
Frontend: `firstFridayAfter()` + `addHours()` helpers, auto-fill on level pick, manual cascade still works if user changes opens time.