### PR TITLE
feat: dynamic roster composition in create league form

### DIFF
--- a/app/blueprints/fantasy.py
+++ b/app/blueprints/fantasy.py
@@ -232,6 +232,9 @@ def get_level_pool():
         return jsonify({
             "max_managers": pool["max_managers"],
             "roster_skaters": pool["roster_skaters"],
+            "skater_count": len(pool.get("skaters", [])),
+            "goalie_count": len(pool.get("goalies", [])),
+            "ref_count": len(pool.get("refs", [])),
             "resolved_season_id": pool.get("resolved_season_id"),
             "resolved_season_name": pool.get("resolved_season_name"),
             "last_game_date": pool.get("last_game_date"),

--- a/app/blueprints/fantasy.py
+++ b/app/blueprints/fantasy.py
@@ -303,21 +303,32 @@ def create_league():
     draft_season_id = pool_info.get("resolved_season_id")
     hb_season_id = None  # will be auto-assigned by scoring service when play season begins
 
-    roster_skaters = pool_info["roster_skaters"]
-    max_managers = pool_info["max_managers"]
-
-    if max_managers < 2:
-        return error_response("VALIDATION_ERROR", "Not enough players at this level to form a league", 400)
-
-    # Allow user to set a lower cap (but never exceed the pool-calculated max)
+    # New logic: user picks max_managers up to total skater count
+    # Roster composition is calculated based on available players
+    total_skaters = len(pool_info.get("skaters", []))
+    total_goalies = len(pool_info.get("goalies", []))
+    total_refs = len(pool_info.get("refs", []))
+    
+    # Default max_managers is min(12, total_skaters) - at least 1 skater per manager
+    max_managers = min(12, total_skaters) if total_skaters >= 2 else 2
+    
+    # Allow user to set any value from 2 up to total skater count
     override = data.get("max_managers_override")
     if override is not None:
         try:
             override = int(override)
-            if 2 <= override <= max_managers:
+            if 2 <= override <= total_skaters:
                 max_managers = override
         except (ValueError, TypeError):
             pass
+    
+    if max_managers < 2:
+        return error_response("VALIDATION_ERROR", "Not enough players at this level to form a league", 400)
+    
+    # Calculate roster composition based on selected manager count
+    roster_skaters = total_skaters // max_managers
+    roster_goalies = 1 if total_goalies >= max_managers else 0
+    roster_refs = 1 if total_refs >= max_managers else 0
 
     # draft_closes_at is mandatory — the entire deadline system depends on it
     if not data.get("draft_closes_at"):
@@ -362,8 +373,8 @@ def create_league():
             status="forming",
             max_managers=max_managers,
             roster_skaters=roster_skaters,
-            roster_goalies=1,
-            roster_refs=1,
+            roster_goalies=roster_goalies,
+            roster_refs=roster_refs,
             draft_pick_hours=data.get("draft_pick_hours", 24),
             created_by=user.id,
             is_private=is_private,

--- a/frontend/src/views/FantasyView.vue
+++ b/frontend/src/views/FantasyView.vue
@@ -181,6 +181,18 @@
             </div>
           </div>
 
+          <!-- Available player counts (shown after level selected) -->
+          <div v-if="createForm.level_id && !poolLoading" class="form-control">
+            <label class="label py-1">
+              <span class="label-text text-sm text-base-content/50">Available players</span>
+            </label>
+            <div class="flex flex-wrap items-center gap-3 px-1">
+              <span class="text-sm"><span class="font-semibold text-primary">{{ poolPlayerCounts.skaters }}</span> skaters</span>
+              <span class="text-sm"><span class="font-semibold text-primary">{{ poolPlayerCounts.goalies }}</span> goalies</span>
+              <span class="text-sm"><span class="font-semibold text-primary">{{ poolPlayerCounts.refs }}</span> refs</span>
+            </div>
+          </div>
+
           <!-- Max managers (shown after level selected, capped by pool) -->
           <div v-if="createForm.level_id" class="form-control">
             <label class="label py-1">
@@ -350,10 +362,11 @@ const hbLeaguesLoading = ref(false)
 const levels = ref([])
 const levelsLoading = ref(false)
 
-// Pool info (max managers cap)
+// Pool info (max managers cap + player counts)
 const poolMaxManagers = ref(null)
 const poolSeasonName = ref(null)
 const poolLoading = ref(false)
+const poolPlayerCounts = ref({ skaters: 0, goalies: 0, refs: 0 })
 
 const managerOptions = computed(() => {
   const max = poolMaxManagers.value || 12
@@ -447,6 +460,7 @@ async function loadLevels(leagueId) {
 
 async function loadPoolInfo(levelId, hbLeagueId) {
   poolMaxManagers.value = null; poolSeasonName.value = null
+  poolPlayerCounts.value = { skaters: 0, goalies: 0, refs: 0 }
   createForm.value.max_managers = null
   if (!levelId) return
   poolLoading.value = true
@@ -456,6 +470,11 @@ async function loadPoolInfo(levelId, hbLeagueId) {
     })
     poolMaxManagers.value = data.max_managers || 12
     poolSeasonName.value = data.resolved_season_name || null
+    poolPlayerCounts.value = {
+      skaters: data.skater_count || 0,
+      goalies: data.goalie_count || 0,
+      refs: data.ref_count || 0,
+    }
     createForm.value.max_managers = poolMaxManagers.value
     // Auto-fill draft dates based on last game in the season
     if (data.last_game_date) {
@@ -481,7 +500,7 @@ async function openCreateModal() {
   createModalKey.value++
   showCreateModal.value = true
   createError.value = ''
-  poolMaxManagers.value = null; poolSeasonName.value = null
+  poolMaxManagers.value = null; poolSeasonName.value = null; poolPlayerCounts.value = { skaters: 0, goalies: 0, refs: 0 }
   createForm.value = {
     hb_league_id: null,
     level_id: null,
@@ -502,7 +521,7 @@ async function openCreateModal() {
 function onLeagueChange() {
   createForm.value.level_id = null
   createForm.value.max_managers = null
-  poolMaxManagers.value = null; poolSeasonName.value = null
+  poolMaxManagers.value = null; poolSeasonName.value = null; poolPlayerCounts.value = { skaters: 0, goalies: 0, refs: 0 }
   loadLevels(createForm.value.hb_league_id)
 }
 

--- a/frontend/src/views/FantasyView.vue
+++ b/frontend/src/views/FantasyView.vue
@@ -193,16 +193,28 @@
             </div>
           </div>
 
-          <!-- Max managers (shown after level selected, capped by pool) -->
+          <!-- Max managers (shown after level selected, up to total skater count) -->
           <div v-if="createForm.level_id" class="form-control">
             <label class="label py-1">
               <span class="label-text text-sm">Max Managers</span>
               <span v-if="poolLoading" class="label-text-alt text-xs text-base-content/40">calculating…</span>
-              <span v-else-if="poolMaxManagers" class="label-text-alt text-xs text-base-content/40">up to {{ poolMaxManagers }} based on player pool</span>
+              <span v-else class="label-text-alt text-xs text-base-content/40">up to {{ poolPlayerCounts.skaters }} (total skaters)</span>
             </label>
             <select v-model.number="createForm.max_managers" class="select select-bordered select-sm" :disabled="poolLoading">
               <option v-for="n in managerOptions" :key="n" :value="n">{{ n }}</option>
             </select>
+          </div>
+
+          <!-- Roster composition preview (shown after max managers selected) -->
+          <div v-if="createForm.level_id && createForm.max_managers && !poolLoading" class="form-control">
+            <label class="label py-1">
+              <span class="label-text text-sm text-base-content/50">Roster per manager</span>
+            </label>
+            <div class="flex flex-wrap items-center gap-3 px-1">
+              <span class="text-sm"><span class="font-semibold text-primary">{{ rosterComposition.skaters }}</span> skaters</span>
+              <span class="text-sm"><span class="font-semibold" :class="rosterComposition.goalies > 0 ? 'text-primary' : 'text-base-content/30'">{{ rosterComposition.goalies }}</span> goalies</span>
+              <span class="text-sm"><span class="font-semibold" :class="rosterComposition.refs > 0 ? 'text-primary' : 'text-base-content/30'">{{ rosterComposition.refs }}</span> refs</span>
+            </div>
           </div>
 
           <!-- Team name -->
@@ -368,8 +380,18 @@ const poolSeasonName = ref(null)
 const poolLoading = ref(false)
 const poolPlayerCounts = ref({ skaters: 0, goalies: 0, refs: 0 })
 
+// Roster composition based on selected manager count
+const rosterComposition = computed(() => {
+  const n = createForm.value.max_managers || 1
+  const skaters = Math.floor((poolPlayerCounts.value.skaters || 0) / n)
+  const goalies = (poolPlayerCounts.value.goalies || 0) >= n ? 1 : 0
+  const refs = (poolPlayerCounts.value.refs || 0) >= n ? 1 : 0
+  return { skaters, goalies, refs }
+})
+
 const managerOptions = computed(() => {
-  const max = poolMaxManagers.value || 12
+  // Max managers = total skater count (each manager needs at least 1 skater)
+  const max = Math.max(2, poolPlayerCounts.value.skaters || 12)
   const opts = []
   for (let i = 2; i <= max; i++) opts.push(i)
   return opts


### PR DESCRIPTION
## Changes

### Backend
-  now returns , , 
- League creation calculates roster dynamically based on user-selected manager count:
  - 
  -  if enough goalies for everyone, else 
  -  if enough refs for everyone, else 

### Frontend
- Create league form shows available player counts (skaters/goalies/refs)
- Max managers dropdown now goes up to total skater count
- Roster preview displays per-manager composition that updates instantly when manager count changes
- Goalies/refs shown in muted color when unavailable (0 count)