### PR TITLE
feat: show H/A jersey number badge in live fantasy games

### DIFF
--- a/app/blueprints/fantasy.py
+++ b/app/blueprints/fantasy.py
@@ -1249,6 +1249,23 @@ def get_league_games(league_id: int):
         for s in score_rows:
             my_scores.setdefault(s.game_id, {})[s.hb_human_id] = s
 
+    # Batch-load live roster info (team + jersey) for OPEN games
+    open_games = {r.id for r in game_rows if r.status == "OPEN"}
+    live_roster_map = {}  # game_id -> {hb_human_id -> {team_id, jersey_number}}
+    if my_roster and open_games:
+        gids_sql = ",".join(str(i) for i in open_games)
+        hids_sql = ",".join(str(h) for h in my_roster)
+        live_rows = hb.execute(text(
+            f"SELECT human_id, game_id, team_id, jersey_number "
+            f"FROM game_rosters "
+            f"WHERE game_id IN ({gids_sql}) AND human_id IN ({hids_sql})"
+        )).fetchall()
+        for r in live_rows:
+            live_roster_map.setdefault(r.game_id, {})[r.human_id] = {
+                "team_id": r.team_id,
+                "jersey_number": r.jersey_number if r.jersey_number else None,
+            }
+
     games = []
     for g_row in game_rows:
         my_players = []
@@ -1270,6 +1287,28 @@ def get_league_games(league_id: int):
                 })
             # Sort: points desc, then name
             my_players.sort(key=lambda p: (-p["points"], p["display_name"]))
+        elif my_roster and g_row.status == "OPEN":
+            game_live_map = live_roster_map.get(g_row.id, {})
+            for hb_human_id in my_roster:
+                lr = game_live_map.get(hb_human_id)
+                if not lr:
+                    continue
+                home_away = "H" if lr["team_id"] == g_row.home_team_id else "A"
+                my_players.append({
+                    "hb_human_id": hb_human_id,
+                    "display_name": human_names.get(hb_human_id, str(hb_human_id)),
+                    "jersey_number": lr["jersey_number"],
+                    "home_away": home_away,
+                    "points": 0.0,
+                    "goals": 0,
+                    "assists": 0,
+                    "penalties": 0,
+                    "games_played": 0,
+                    "is_goalie_win": False,
+                    "is_shutout": False,
+                    "ref_games": 0,
+                })
+            my_players.sort(key=lambda p: (p["home_away"], p["display_name"]))
 
         games.append({
             "id": g_row.id,

--- a/frontend/src/views/FantasyLeagueView.vue
+++ b/frontend/src/views/FantasyLeagueView.vue
@@ -525,6 +525,10 @@
                     :key="p.hb_human_id"
                     class="flex items-center gap-1 rounded px-2 py-0.5 text-xs bg-base-300"
                   >
+                    <span v-if="p.home_away" class="badge badge-xs font-mono mr-0.5"
+                      :class="p.home_away === 'H' ? 'badge-primary' : 'badge-secondary'">
+                      {{ p.home_away }}<span v-if="p.jersey_number">#{{ p.jersey_number }}</span>
+                    </span>
                     <span class="font-medium">{{ p.display_name }}</span>
                     <span class="font-bold" :class="p.points < 0 ? 'text-error' : 'text-primary'">{{ Number(p.points).toFixed(1) }}</span>
                     <span v-if="p.goals" class="text-success">{{ p.goals }}G</span>
@@ -538,7 +542,7 @@
                 </div>
                 <!-- Zeroes: just names, dimmed -->
                 <div v-if="game.my_players.some(p => p.points === 0 && !p.penalties)" class="text-xs text-base-content/35 leading-relaxed">
-                  {{ game.my_players.filter(p => p.points === 0 && !p.penalties).map(p => p.display_name).join(', ') }}
+                  {{ game.my_players.filter(p => p.points === 0 && !p.penalties).map(p => p.home_away ? `${p.home_away}${p.jersey_number ? '#' + p.jersey_number : ''} ${p.display_name}` : p.display_name).join(', ') }}
                 </div>
               </div>
               <!-- Stats link -->


### PR DESCRIPTION
In the fantasy Games tab, live (OPEN) games now show each rostered player with an `H#19` or `A#19` badge.

- Backend: batch-queries `game_rosters` for OPEN games + rostered human_ids, adds `home_away` (H/A) and `jersey_number` to each player entry
- Frontend: badge before player name — primary color for home, secondary for away; gated on `home_away` being present so finished games are unaffected
- Zeroes row also prefixed: `H#19 Player Name`

Test with league 118 while a game is OPEN.