### PR TITLE
feat: live provisional fantasy scoring for in-progress games

### DIFF
--- a/app/blueprints/fantasy.py
+++ b/app/blueprints/fantasy.py
@@ -1003,6 +1003,7 @@ def get_roster(league_id: int, user_id: int):
             func.sum(FantasyGameScores.penalties).label("penalties"),
             func.sum(FantasyGameScores.games_played).label("gp"),
             func.sum(FantasyGameScores.points).label("total_pts"),
+            func.bool_or(FantasyGameScores.is_provisional).label("has_provisional"),
         )
         .where(
             FantasyGameScores.league_id == league_id,
@@ -1017,6 +1018,7 @@ def get_roster(league_id: int, user_id: int):
             "penalties": int(r.penalties or 0),
             "gp": int(r.gp or 0),
             "total_pts": float(r.total_pts or 0),
+            "has_provisional": bool(r.has_provisional or False),
         }
         for r in stats_rows
     }
@@ -1118,6 +1120,7 @@ def get_roster(league_id: int, user_id: int):
         d["is_live"] = r.hb_human_id in live_human_ids
         d["live_game_id"] = live_game_id_map.get(r.hb_human_id) if r.hb_human_id in live_human_ids else None
         d["jersey_number"] = jersey_map.get(r.hb_human_id)
+        d["is_live_scoring"] = bool(s.get("has_provisional", False))
         result.append(d)
 
     # Sort: goalies last, then by fantasy_points desc
@@ -1266,6 +1269,21 @@ def get_league_games(league_id: int):
                 "jersey_number": r.jersey_number if r.jersey_number else None,
             }
 
+    # Batch-load provisional scores for OPEN games
+    live_score_map = {}  # game_id -> {hb_human_id -> FantasyGameScores}
+    if my_roster and open_games:
+        from app.models.fantasy_game_scores import FantasyGameScores
+        live_score_rows = pred.execute(
+            select(FantasyGameScores).where(
+                FantasyGameScores.league_id == league_id,
+                FantasyGameScores.user_id == view_user_id,
+                FantasyGameScores.game_id.in_(open_games),
+                FantasyGameScores.is_provisional.is_(True),
+            )
+        ).scalars().all()
+        for s in live_score_rows:
+            live_score_map.setdefault(s.game_id, {})[s.hb_human_id] = s
+
     games = []
     for g_row in game_rows:
         my_players = []
@@ -1289,24 +1307,27 @@ def get_league_games(league_id: int):
             my_players.sort(key=lambda p: (-p["points"], p["display_name"]))
         elif my_roster and g_row.status == "OPEN":
             game_live_map = live_roster_map.get(g_row.id, {})
+            game_live_scores = live_score_map.get(g_row.id, {})
             for hb_human_id in my_roster:
                 lr = game_live_map.get(hb_human_id)
                 if not lr:
                     continue
                 home_away = "H" if lr["team_id"] == g_row.home_team_id else "A"
+                sc = game_live_scores.get(hb_human_id)
                 my_players.append({
                     "hb_human_id": hb_human_id,
                     "display_name": human_names.get(hb_human_id, str(hb_human_id)),
                     "jersey_number": lr["jersey_number"],
                     "home_away": home_away,
-                    "points": 0.0,
-                    "goals": 0,
-                    "assists": 0,
-                    "penalties": 0,
-                    "games_played": 0,
-                    "is_goalie_win": False,
-                    "is_shutout": False,
-                    "ref_games": 0,
+                    "points": float(sc.points) if sc else 0.0,
+                    "goals": sc.goals if sc else 0,
+                    "assists": sc.assists if sc else 0,
+                    "penalties": sc.penalties if sc else 0,
+                    "games_played": sc.games_played if sc else 0,
+                    "is_goalie_win": sc.is_goalie_win if sc else False,
+                    "is_shutout": sc.is_shutout if sc else False,
+                    "ref_games": sc.ref_games if sc else 0,
+                    "is_provisional": True,
                 })
             my_players.sort(key=lambda p: (p["home_away"], p["display_name"]))
 

--- a/app/jobs/grade_results.py
+++ b/app/jobs/grade_results.py
@@ -274,6 +274,30 @@ def start_scheduler(app):
         replace_existing=True,
     )
 
+    def _fantasy_live_score_job():
+        """Provisionally score in-progress (OPEN) games for active fantasy leagues."""
+        with _app.app_context():
+            try:
+                from app.services.fantasy_scoring_service import score_live_games
+                summary = score_live_games()
+                if summary["games"] > 0 or summary["errors"] > 0:
+                    logger.info(
+                        "[fantasy-live] Live-scored leagues=%d games=%d errors=%d",
+                        summary.get("leagues", 0),
+                        summary.get("games", 0),
+                        summary.get("errors", 0),
+                    )
+            except Exception as exc:
+                logger.exception("[fantasy-live] Unhandled error in live score job: %s", exc)
+
+    _scheduler.add_job(
+        func=_fantasy_live_score_job,
+        trigger=IntervalTrigger(minutes=2),
+        id="fantasy_live_scoring",
+        name="Score live in-progress fantasy games",
+        replace_existing=True,
+    )
+
     _scheduler.start()
     logger.info("[grader] Scheduler started. Interval: %d minutes", interval_minutes)
 

--- a/app/models/fantasy_game_scores.py
+++ b/app/models/fantasy_game_scores.py
@@ -32,6 +32,7 @@ class FantasyGameScores(PredBase):
     ref_penalties: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
     ref_gm: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
     points: Mapped[float] = mapped_column(Numeric(6, 1), nullable=False, default=0)
+    is_provisional: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
     scored_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         default=lambda: datetime.now(timezone.utc),
@@ -55,6 +56,7 @@ class FantasyGameScores(PredBase):
             "ref_penalties": self.ref_penalties,
             "ref_gm": self.ref_gm,
             "points": float(self.points),
+            "is_provisional": self.is_provisional,
             "scored_at": self.scored_at.isoformat() if self.scored_at else None,
         }
 

--- a/app/services/fantasy_scoring_service.py
+++ b/app/services/fantasy_scoring_service.py
@@ -215,11 +215,12 @@ def score_game(league_id: int, game_id: int) -> None:
                 goals=0, assists=0, penalties=0, games_played=0,
                 is_goalie_win=False, is_shutout=False,
                 ref_games=rs["games"], ref_penalties=rs["penalties"], ref_gm=rs["gm"],
-                points=pts, scored_at=now,
+                points=pts, scored_at=now, is_provisional=False,
             ).on_conflict_do_update(
                 constraint="uq_fantasy_game_scores_league_human_game",
                 set_={"ref_games": rs["games"], "ref_penalties": rs["penalties"],
-                      "ref_gm": rs["gm"], "points": pts, "scored_at": now}
+                      "ref_gm": rs["gm"], "points": pts, "scored_at": now,
+                      "is_provisional": False}
             )
             pred.execute(stmt)
             scored += 1
@@ -258,16 +259,18 @@ def score_game(league_id: int, game_id: int) -> None:
             is_shutout=is_shutout,
             points=pts,
             scored_at=now,
+            is_provisional=False,
         ).on_conflict_do_update(
             constraint="uq_fantasy_game_scores_league_human_game",
             set_={
-                "goals":         goals,
-                "assists":       assists,
-                "penalties":     penalties,
-                "is_goalie_win": is_goalie_win,
-                "is_shutout":    is_shutout,
-                "points":        pts,
-                "scored_at":     now,
+                "goals":          goals,
+                "assists":        assists,
+                "penalties":      penalties,
+                "is_goalie_win":  is_goalie_win,
+                "is_shutout":     is_shutout,
+                "points":         pts,
+                "scored_at":      now,
+                "is_provisional": False,
             }
         )
         pred.execute(stmt)
@@ -278,6 +281,263 @@ def score_game(league_id: int, game_id: int) -> None:
 
     # ── Update standings ──────────────────────────────────────────────────────
     _update_standings(league_id, pred)
+
+
+def score_live_game(league_id: int, game_id: int) -> None:
+    """
+    Provisionally score an in-progress (OPEN) HB game for all rostered players.
+    Skips goalie win/shutout (not yet decided). Marks rows is_provisional=True.
+    Upserts into fantasy_game_scores and updates fantasy_standings.
+    """
+    hb = HBSession()
+    pred = PredSession()
+
+    roster_stmt = select(FantasyRoster).where(FantasyRoster.league_id == league_id)
+    roster = pred.execute(roster_stmt).scalars().all()
+    if not roster:
+        return
+
+    rostered_ids = {r.hb_human_id: r for r in roster}
+
+    try:
+        participants = {
+            r.human_id
+            for r in hb.execute(
+                text("SELECT human_id FROM game_rosters WHERE game_id = :gid"),
+                {"gid": game_id},
+            ).fetchall()
+        }
+    except Exception as e:
+        logger.warning("score_live_game: could not query game_rosters for game %d: %s", game_id, e)
+        try:
+            hb.rollback()
+        except Exception:
+            pass
+        return
+
+    goals_by_player: dict[int, int] = {}
+    assists_by_player: dict[int, int] = {}
+    try:
+        goal_rows = hb.execute(
+            text("SELECT goal_scorer_id, assist_1_id, assist_2_id "
+                 "FROM goals WHERE game_id = :gid"),
+            {"gid": game_id},
+        ).fetchall()
+        for g in goal_rows:
+            if g.goal_scorer_id:
+                goals_by_player[g.goal_scorer_id] = goals_by_player.get(g.goal_scorer_id, 0) + 1
+            if g.assist_1_id:
+                assists_by_player[g.assist_1_id] = assists_by_player.get(g.assist_1_id, 0) + 1
+            if g.assist_2_id:
+                assists_by_player[g.assist_2_id] = assists_by_player.get(g.assist_2_id, 0) + 1
+    except Exception as e:
+        logger.warning("score_live_game: could not query goals for game %d: %s", game_id, e)
+        try:
+            hb.rollback()
+        except Exception:
+            pass
+
+    penalties_by_player: dict[int, int] = {}
+    try:
+        pen_rows = hb.execute(
+            text("SELECT penalized_player_id FROM penalties WHERE game_id = :gid"),
+            {"gid": game_id},
+        ).fetchall()
+        for p in pen_rows:
+            if p.penalized_player_id:
+                penalties_by_player[p.penalized_player_id] = (
+                    penalties_by_player.get(p.penalized_player_id, 0) + 1
+                )
+    except Exception as e:
+        logger.warning("score_live_game: could not query penalties for game %d: %s", game_id, e)
+        try:
+            hb.rollback()
+        except Exception:
+            pass
+
+    # Ref stats — count what's been called so far
+    ref_stats: dict[int, dict] = {}
+    try:
+        ref_rows = hb.execute(
+            text("SELECT human_id FROM ref_divisions WHERE game_id = :gid"),
+            {"gid": game_id},
+        ).fetchall()
+        for r in ref_rows:
+            if r.human_id not in ref_stats:
+                ref_stats[r.human_id] = {"games": 1, "penalties": 0, "gm": 0}
+        ref_pen_rows = hb.execute(
+            text("""SELECT referee_id,
+                    COUNT(*) AS cnt,
+                    SUM(CASE WHEN LOWER(penalty_type) LIKE '%game misconduct%' THEN 1 ELSE 0 END) AS gm_cnt
+                    FROM penalties WHERE game_id = :gid AND referee_id IS NOT NULL
+                    GROUP BY referee_id"""),
+            {"gid": game_id},
+        ).fetchall()
+        for r in ref_pen_rows:
+            if r.referee_id in ref_stats:
+                ref_stats[r.referee_id]["penalties"] = int(r.cnt or 0)
+                ref_stats[r.referee_id]["gm"] = int(r.gm_cnt or 0)
+    except Exception as e:
+        logger.debug("score_live_game: ref stats unavailable for game %d: %s", game_id, e)
+        try:
+            hb.rollback()
+        except Exception:
+            pass
+
+    now = datetime.now(timezone.utc)
+    scored = 0
+
+    for hb_human_id, roster_entry in rostered_ids.items():
+        if roster_entry.is_ref:
+            if hb_human_id not in ref_stats:
+                continue
+            rs = ref_stats[hb_human_id]
+            pts = _compute_points(
+                goals=0, assists=0, penalties=0, games_played=0,
+                is_goalie_win=False, is_shutout=False,
+                ref_games=rs["games"], ref_penalties=rs["penalties"], ref_gm=rs["gm"],
+            )
+            stmt = pg_insert(FantasyGameScores).values(
+                league_id=league_id,
+                user_id=roster_entry.user_id,
+                hb_human_id=hb_human_id,
+                game_id=game_id,
+                goals=0, assists=0, penalties=0, games_played=0,
+                is_goalie_win=False, is_shutout=False,
+                ref_games=rs["games"], ref_penalties=rs["penalties"], ref_gm=rs["gm"],
+                points=pts, scored_at=now, is_provisional=True,
+            ).on_conflict_do_update(
+                constraint="uq_fantasy_game_scores_league_human_game",
+                set_={"ref_games": rs["games"], "ref_penalties": rs["penalties"],
+                      "ref_gm": rs["gm"], "points": pts, "scored_at": now,
+                      "is_provisional": True}
+            )
+            pred.execute(stmt)
+            scored += 1
+            continue
+
+        if hb_human_id not in participants:
+            continue
+
+        goals     = goals_by_player.get(hb_human_id, 0)
+        assists   = assists_by_player.get(hb_human_id, 0)
+        penalties = penalties_by_player.get(hb_human_id, 0)
+
+        # Goalie win/shutout NOT available in-progress — skip
+        pts = _compute_points(
+            goals=goals,
+            assists=assists,
+            penalties=penalties,
+            games_played=1,
+            is_goalie_win=False,
+            is_shutout=False,
+            is_goalie=roster_entry.is_goalie,
+        )
+
+        stmt = pg_insert(FantasyGameScores).values(
+            league_id=league_id,
+            user_id=roster_entry.user_id,
+            hb_human_id=hb_human_id,
+            game_id=game_id,
+            goals=goals,
+            assists=assists,
+            penalties=penalties,
+            games_played=1,
+            is_goalie_win=False,
+            is_shutout=False,
+            points=pts,
+            scored_at=now,
+            is_provisional=True,
+        ).on_conflict_do_update(
+            constraint="uq_fantasy_game_scores_league_human_game",
+            set_={
+                "goals":          goals,
+                "assists":        assists,
+                "penalties":      penalties,
+                "is_goalie_win":  False,
+                "is_shutout":     False,
+                "points":         pts,
+                "scored_at":      now,
+                "is_provisional": True,
+            }
+        )
+        pred.execute(stmt)
+        scored += 1
+
+    pred.commit()
+    logger.debug("score_live_game: league=%d game=%d scored=%d players (provisional)",
+                 league_id, game_id, scored)
+
+    _update_standings(league_id, pred)
+
+
+def score_live_games() -> dict:
+    """
+    Find OPEN games in active leagues' divisions and score them provisionally.
+    Re-scores previously-provisional games (so live points stay current),
+    but skips games already finalized (is_provisional=False rows exist).
+    Returns summary: {"leagues": int, "games": int, "errors": int}
+    """
+    pred = PredSession()
+    summary = {"leagues": 0, "games": 0, "errors": 0}
+
+    try:
+        from app.models.fantasy_league import FantasyLeague
+        leagues = pred.execute(
+            select(FantasyLeague).where(FantasyLeague.status == "active")
+        ).scalars().all()
+    except Exception as e:
+        logger.exception("[fantasy-live] Could not load active leagues: %s", e)
+        return summary
+
+    for league in leagues:
+        summary["leagues"] += 1
+        hb = HBSession()
+        try:
+            if league.hb_division_id:
+                div_ids_sql = str(league.hb_division_id)
+            else:
+                continue  # need cached division for fast lookup; final scorer fills this in
+
+            open_games = hb.execute(
+                text(
+                    f"SELECT id FROM games WHERE division_id IN ({div_ids_sql}) "
+                    "AND status = 'OPEN'"
+                )
+            ).fetchall()
+
+            if not open_games:
+                continue
+
+            already_finalized = {
+                r.game_id
+                for r in pred.execute(
+                    text("SELECT DISTINCT game_id FROM fantasy_game_scores "
+                         "WHERE league_id = :lid AND is_provisional = FALSE"),
+                    {"lid": league.id},
+                ).fetchall()
+            }
+
+            for game_row in open_games:
+                if game_row.id in already_finalized:
+                    continue
+                try:
+                    score_live_game(league.id, game_row.id)
+                    summary["games"] += 1
+                except Exception as ge:
+                    logger.warning("[fantasy-live] score_live_game(%d, %d) failed: %s",
+                                   league.id, game_row.id, ge)
+                    summary["errors"] += 1
+
+        except Exception as le:
+            logger.exception("[fantasy-live] Error processing league %d: %s", league.id, le)
+            summary["errors"] += 1
+            try:
+                hb.rollback()
+            except Exception:
+                pass
+
+    return summary
 
 
 def auto_assign_seasons() -> dict:
@@ -435,10 +695,13 @@ def score_active_leagues() -> dict:
             if not final_games:
                 continue
 
+            # Only treat games as already-scored when their rows are non-provisional.
+            # Provisional rows from live scoring should be re-scored to finalize them.
             already_scored = {
                 r.game_id
                 for r in pred.execute(
-                    text("SELECT DISTINCT game_id FROM fantasy_game_scores WHERE league_id = :lid"),
+                    text("SELECT DISTINCT game_id FROM fantasy_game_scores "
+                         "WHERE league_id = :lid AND is_provisional = FALSE"),
                     {"lid": league.id},
                 ).fetchall()
             }

--- a/frontend/src/views/FantasyLeagueView.vue
+++ b/frontend/src/views/FantasyLeagueView.vue
@@ -432,7 +432,7 @@
             <thead>
               <tr>
                 <th>#</th>
-                <th>Team</th>
+                <th>Team <span v-if="league.has_live_game" class="badge badge-xs badge-warning ml-1 animate-pulse">⚡ LIVE</span></th>
                 <th>Manager</th>
                 <th class="text-right">Week Pts</th>
                 <th class="text-right font-bold">Total Pts</th>
@@ -523,14 +523,14 @@
                   <div
                     v-for="p in game.my_players.filter(p => p.points !== 0 || p.penalties > 0)"
                     :key="p.hb_human_id"
-                    class="flex items-center gap-1 rounded px-2 py-0.5 text-xs bg-base-300"
+                    :class="['flex items-center gap-1 rounded px-2 py-0.5 text-xs', p.is_provisional ? 'bg-warning/20 border border-warning/30' : 'bg-base-300']"
                   >
                     <span v-if="p.home_away" class="badge badge-xs font-mono mr-0.5"
                       :class="p.home_away === 'H' ? 'badge-primary' : 'badge-secondary'">
                       {{ p.home_away }}<span v-if="p.jersey_number">#{{ p.jersey_number }}</span>
                     </span>
                     <span class="font-medium">{{ p.display_name }}</span>
-                    <span class="font-bold" :class="p.points < 0 ? 'text-error' : 'text-primary'">{{ Number(p.points).toFixed(1) }}</span>
+                    <span class="font-bold" :class="p.points < 0 ? 'text-error' : p.is_provisional ? 'text-warning' : 'text-primary'">{{ p.is_provisional ? '⚡' : '' }}{{ Number(p.points).toFixed(1) }}</span>
                     <span v-if="p.goals" class="text-success">{{ p.goals }}G</span>
                     <span v-if="p.assists" class="text-info">{{ p.assists }}A</span>
                     <span v-if="p.is_goalie_win" class="text-warning">W</span>
@@ -697,7 +697,11 @@ const RosterList = {
           h('td', { class: 'text-right text-xs px-3 py-1 opacity-70 whitespace-nowrap' }, p.assists ?? 0),
           h('td', { class: 'text-right text-xs px-3 py-1 whitespace-nowrap ' + (p.penalties ? 'text-error' : 'opacity-70') }, p.penalties ?? 0),
           h('td', { class: 'text-right text-xs pl-3 py-1 font-semibold text-primary whitespace-nowrap' },
-            p.fantasy_points != null ? p.fantasy_points.toFixed(1) : '—'),
+            p.fantasy_points != null
+            ? (p.is_live_scoring
+              ? [h('span', { title: 'Live — goalie win pending' }, '⚡'), p.fantasy_points.toFixed(1)]
+              : p.fantasy_points.toFixed(1))
+            : '—'),
         ])
       })
 
@@ -1229,7 +1233,23 @@ watch(isAuthenticated, (authed) => {
 
 // Auto-refresh draft state every 30s when draft is active
 let _draftPollInterval = null
-onUnmounted(() => { if (_draftPollInterval) clearInterval(_draftPollInterval) })
+onUnmounted(() => {
+  if (_draftPollInterval) clearInterval(_draftPollInterval)
+  if (_livePollInterval) clearInterval(_livePollInterval)
+})
+
+// Auto-refresh every 60s when there are live games
+let _livePollInterval = null
+watch(() => league.value?.has_live_game, (hasLive) => {
+  if (_livePollInterval) { clearInterval(_livePollInterval); _livePollInterval = null }
+  if (hasLive) {
+    _livePollInterval = setInterval(async () => {
+      await loadLeague({ silent: true })
+      if (activeTab.value === 'games') loadGames(viewUserId.value)
+      if (activeTab.value === 'standings') loadStandings()
+    }, 60000)
+  }
+}, { immediate: true })
 
 watch(() => league.value?.status, (status) => {
   if (_draftPollInterval) { clearInterval(_draftPollInterval); _draftPollInterval = null }

--- a/migrations/versions/u1v2w3x4y5z6_add_is_provisional_to_fantasy_game_scores.py
+++ b/migrations/versions/u1v2w3x4y5z6_add_is_provisional_to_fantasy_game_scores.py
@@ -1,0 +1,24 @@
+"""add is_provisional to fantasy_game_scores
+
+Revision ID: u1v2w3x4y5z6
+Revises: t0u1v2w3x4y5
+Create Date: 2026-05-06
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = 'u1v2w3x4y5z6'
+down_revision = 't0u1v2w3x4y5'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        'fantasy_game_scores',
+        sa.Column('is_provisional', sa.Boolean(), nullable=False, server_default='false'),
+    )
+
+
+def downgrade():
+    op.drop_column('fantasy_game_scores', 'is_provisional')


### PR DESCRIPTION
Scores OPEN games every 2 minutes (provisional — no goalie win/shutout until Final). Finalizes automatically when game status becomes Final.

**Backend:**
- `is_provisional` column on `fantasy_game_scores` (migration included)
- `score_live_game()` — scores OPEN games, marks rows `is_provisional=True`, skips goalie win/shutout
- `score_live_games()` — finds all OPEN games across active leagues, skips already-finalized
- Scheduler: 2-min live scoring job in addition to existing 5-min final scoring job
- `get_roster()` API: adds `is_live_scoring` flag when player has provisional scores
- `get_games()` API: OPEN game players now get live goals/assists/penalties/points from DB

**Frontend:**
- ⚡ amber badge on provisional points in the Games tab player chips
- ⚡ amber FP column in Roster tab with tooltip 'Live — goalie win pending'
- ⚡ LIVE pulse badge on Standings header when league has active games
- Auto-polls games + standings every 60s while live games are running; stops when none

Test with league 118.