### PR TITLE
Fantasy scoring: skip games before season_starts_at

### DIFF
--- a/app/services/fantasy_scoring_service.py
+++ b/app/services/fantasy_scoring_service.py
@@ -499,11 +499,18 @@ def score_live_games() -> dict:
             else:
                 continue  # need cached division for fast lookup; final scorer fills this in
 
+            date_filter = ""
+            date_params = {}
+            if league.season_starts_at:
+                date_filter = " AND date >= :season_start"
+                date_params = {"season_start": league.season_starts_at.date()}
+
             open_games = hb.execute(
                 text(
                     f"SELECT id FROM games WHERE division_id IN ({div_ids_sql}) "
-                    "AND status = 'OPEN'"
-                )
+                    f"AND status = 'OPEN'{date_filter}"
+                ),
+                date_params or None,
             ).fetchall()
 
             if not open_games:
@@ -685,11 +692,18 @@ def score_active_leagues() -> dict:
                     pred.commit()
                 except Exception:
                     pred.rollback()
+            date_filter = ""
+            date_params = {}
+            if league.season_starts_at:
+                date_filter = " AND date >= :season_start"
+                date_params = {"season_start": league.season_starts_at.date()}
+
             final_games = hb.execute(
                 text(
                     f"SELECT id FROM games WHERE division_id IN ({div_ids_sql}) "
-                    "AND status IN ('Final','Final.','Final/OT','Final/OT2','Final/SO','Final(SO)')"
-                )
+                    f"AND status IN ('Final','Final.','Final/OT','Final/OT2','Final/SO','Final(SO)'){date_filter}"
+                ),
+                date_params or None,
             ).fetchall()
 
             if not final_games:


### PR DESCRIPTION
## Problem
`score_active_leagues()` fetched ALL final games in the division with no date filter. Setting `season_starts_at` had no effect on which games counted for points.

## Fix
When a league has `season_starts_at` set, both `score_active_leagues()` and `score_live_games()` now append `AND date >= :season_start` to the game queries.

**Result:** Games played before the fantasy season start date are excluded from points calculation. Leagues without `season_starts_at` set are fully unaffected.

## Testing
Set `season_starts_at` to this week on league 121 → last week's games should not be scored.