### PR TITLE
Fantasy draft: admin block list

### DIFF
--- a/app/blueprints/admin.py
+++ b/app/blueprints/admin.py
@@ -946,6 +946,103 @@ def clear_scoring_season(league_id: int):
     return jsonify({"ok": True, "league_id": league_id})
 
 
+@admin_bp.route("/fantasy/leagues/<int:league_id>/blocked-players", methods=["GET"])
+@require_admin
+def get_blocked_players(league_id: int):
+    """
+    GET /api/admin/fantasy/leagues/<id>/blocked-players
+    Returns the merged player pool for this league plus the current block list.
+    Each pool entry: {hb_human_id, name, fantasy_points, role}.
+    """
+    from app.models.fantasy_league import FantasyLeague
+    from app.services.fantasy_pool_service import get_player_pool
+
+    pred = PredSession()
+    league = pred.get(FantasyLeague, league_id)
+    if not league:
+        return error_response("NOT_FOUND", f"No league with id={league_id}", 404)
+
+    blocked = list((league.settings or {}).get("draft_blocked", []))
+
+    try:
+        pool = get_player_pool(
+            league.level_id,
+            org_id=league.org_id,
+            league_id=league.hb_league_id,
+            season_id=league.draft_season_id or league.hb_season_id,
+            min_games=league.min_games_played or 1,
+        )
+    except Exception as e:
+        logging.getLogger(__name__).warning(
+            "Could not load pool for league %d: %s", league_id, e
+        )
+        return jsonify({"blocked": blocked, "pool": []})
+
+    def _role(p):
+        roles = []
+        if p.get("is_skater"):
+            roles.append("S")
+        if p.get("is_goalie"):
+            roles.append("G")
+        if p.get("is_ref"):
+            roles.append("R")
+        return "/".join(roles) or "—"
+
+    pool_out = [
+        {
+            "hb_human_id": p["hb_human_id"],
+            "name": f"{p.get('first_name', '')} {p.get('last_name', '')}".strip(),
+            "fantasy_points": p.get("fantasy_points", 0.0),
+            "role": _role(p),
+            "is_skater": bool(p.get("is_skater")),
+            "is_goalie": bool(p.get("is_goalie")),
+            "is_ref": bool(p.get("is_ref")),
+        }
+        for p in pool.get("players", [])
+    ]
+    pool_out.sort(key=lambda x: x["fantasy_points"], reverse=True)
+
+    return jsonify({"blocked": blocked, "pool": pool_out})
+
+
+@admin_bp.route("/fantasy/leagues/<int:league_id>/blocked-players", methods=["POST"])
+@require_admin
+def toggle_blocked_player(league_id: int):
+    """
+    POST /api/admin/fantasy/leagues/<id>/blocked-players
+    Body: {"hb_human_id": 123, "blocked": true/false}
+    Toggles a player in/out of settings.draft_blocked list.
+    """
+    from app.models.fantasy_league import FantasyLeague
+
+    data = request.get_json(silent=True) or {}
+    hb_human_id = data.get("hb_human_id")
+    blocked = data.get("blocked")
+
+    if not isinstance(hb_human_id, int):
+        return error_response("VALIDATION_ERROR", "hb_human_id must be an integer", 400)
+    if not isinstance(blocked, bool):
+        return error_response("VALIDATION_ERROR", "blocked must be a boolean", 400)
+
+    pred = PredSession()
+    league = pred.get(FantasyLeague, league_id)
+    if not league:
+        return error_response("NOT_FOUND", f"No league with id={league_id}", 404)
+
+    settings = dict(league.settings or {})
+    current = list(settings.get("draft_blocked", []))
+    current_set = set(current)
+    if blocked:
+        current_set.add(hb_human_id)
+    else:
+        current_set.discard(hb_human_id)
+    settings["draft_blocked"] = sorted(current_set)
+    league.settings = settings  # reassign so SQLAlchemy detects the JSONB change
+    pred.commit()
+
+    return jsonify({"ok": True, "blocked": settings["draft_blocked"]})
+
+
 @admin_bp.route("/chat/questions", methods=["GET"])
 @require_admin
 def chat_questions():

--- a/app/services/fantasy_draft_service.py
+++ b/app/services/fantasy_draft_service.py
@@ -372,6 +372,11 @@ def make_pick(league_id: int, user_id: int, hb_human_id: int) -> dict:
     if pred.execute(existing_stmt).scalar_one_or_none() is not None:
         raise ValueError("Player already drafted in this league")
 
+    # Check player not blocked by admin
+    blocked_ids = set((league.settings or {}).get("draft_blocked", []))
+    if hb_human_id in blocked_ids:
+        raise ValueError("Player is blocked from this draft")
+
     # Determine if goalie
     pool = _get_pool(league_id)
     # Search the correct pool based on pick type to avoid cross-contamination
@@ -461,16 +466,20 @@ def _best_available_from_queue_only(league_id: int, user_id: int, pred, league, 
     pool = _get_pool(league_id)
     drafted_stmt = select(FantasyRoster.hb_human_id).where(FantasyRoster.league_id == league_id)
     drafted_ids = set(pred.execute(drafted_stmt).scalars().all())
+    blocked_ids = set((league.settings or {}).get("draft_blocked", []) if league else [])
 
     is_goalie_pick = current_slot.is_goalie_pick if current_slot else False
     is_ref_pick = current_slot.is_ref_pick if current_slot else False
 
     if is_goalie_pick:
-        eligible = {p["hb_human_id"]: p for p in pool["goalies"] if p["hb_human_id"] not in drafted_ids}
+        eligible = {p["hb_human_id"]: p for p in pool["goalies"]
+                    if p["hb_human_id"] not in drafted_ids and p["hb_human_id"] not in blocked_ids}
     elif is_ref_pick:
-        eligible = {p["hb_human_id"]: p for p in pool.get("refs", []) if p["hb_human_id"] not in drafted_ids}
+        eligible = {p["hb_human_id"]: p for p in pool.get("refs", [])
+                    if p["hb_human_id"] not in drafted_ids and p["hb_human_id"] not in blocked_ids}
     else:
-        all_skaters = [p for p in pool["skaters"] if p["hb_human_id"] not in drafted_ids]
+        all_skaters = [p for p in pool["skaters"]
+                       if p["hb_human_id"] not in drafted_ids and p["hb_human_id"] not in blocked_ids]
         eligible = {p["hb_human_id"]: p for p in all_skaters}
 
     for item in queue_items:
@@ -492,6 +501,7 @@ def _best_available(league_id: int, user_id: int, pred, league, current_slot=Non
         FantasyRoster.league_id == league_id
     )
     drafted_ids = set(pred.execute(drafted_stmt).scalars().all())
+    blocked_ids = set((league.settings or {}).get("draft_blocked", []) if league else [])
 
     # Check what the manager still needs
     manager_roster_stmt = select(FantasyRoster).where(
@@ -513,17 +523,22 @@ def _best_available(league_id: int, user_id: int, pred, league, current_slot=Non
     # Build the full available pool for this pick type
     all_pool = pool["goalies"] + pool.get("refs", []) + pool["skaters"]
     if is_goalie_pick:
-        eligible = [p for p in pool["goalies"] if p["hb_human_id"] not in drafted_ids]
+        eligible = [p for p in pool["goalies"]
+                    if p["hb_human_id"] not in drafted_ids and p["hb_human_id"] not in blocked_ids]
     elif is_ref_pick:
-        eligible = [p for p in pool.get("refs", []) if p["hb_human_id"] not in drafted_ids]
+        eligible = [p for p in pool.get("refs", [])
+                    if p["hb_human_id"] not in drafted_ids and p["hb_human_id"] not in blocked_ids]
     else:
-        eligible = [p for p in all_pool if p["hb_human_id"] not in drafted_ids
+        eligible = [p for p in all_pool
+                    if p["hb_human_id"] not in drafted_ids
+                    and p["hb_human_id"] not in blocked_ids
                     and not p.get("is_ref")]
         # If this manager must pick a goalie now (last picks remaining = goalies needed),
         # force goalie regardless of queue
         force_goalie = (picks_remaining > 0 and picks_remaining <= goalies_still_needed)
         if force_goalie:
-            eligible = [p for p in pool["goalies"] if p["hb_human_id"] not in drafted_ids]
+            eligible = [p for p in pool["goalies"]
+                        if p["hb_human_id"] not in drafted_ids and p["hb_human_id"] not in blocked_ids]
 
     if not eligible:
         return None

--- a/frontend/src/views/AdminView.vue
+++ b/frontend/src/views/AdminView.vue
@@ -583,6 +583,69 @@
                         </div>
                         <div v-if="leagueEditError" class="text-error text-xs self-center">{{ leagueEditError }}</div>
                       </div>
+
+                      <!-- ── Draft Block List ─────────────────────────────── -->
+                      <div class="mt-4 pt-3 border-t border-base-100">
+                        <div class="flex items-center justify-between mb-2">
+                          <div class="text-sm font-bold">🚫 Draft Block List
+                            <span v-if="blockedList.length" class="badge badge-error badge-xs ml-1">{{ blockedList.length }} blocked</span>
+                          </div>
+                          <input
+                            v-model="blockedSearch"
+                            type="text"
+                            placeholder="Search players…"
+                            class="input input-bordered input-xs w-48"
+                          />
+                        </div>
+                        <div v-if="blockedLoading" class="flex justify-center py-3">
+                          <span class="loading loading-spinner loading-sm"></span>
+                        </div>
+                        <div v-else-if="blockedError" class="alert alert-error text-xs py-1">{{ blockedError }}</div>
+                        <div v-else-if="!blockedPool.length" class="text-xs text-base-content/40 py-2">No players in pool.</div>
+                        <div v-else class="max-h-72 overflow-y-auto rounded border border-base-100">
+                          <table class="table table-xs">
+                            <thead class="bg-base-200 sticky top-0 z-10">
+                              <tr>
+                                <th>Player</th>
+                                <th class="w-16 text-center">Role</th>
+                                <th class="w-20 text-right">Pts</th>
+                                <th class="w-24 text-right"></th>
+                              </tr>
+                            </thead>
+                            <tbody>
+                              <tr
+                                v-for="p in filteredBlockedPool"
+                                :key="p.hb_human_id"
+                                :class="isBlocked(p.hb_human_id) ? 'bg-error/10 text-error' : ''"
+                              >
+                                <td class="font-medium">{{ p.name || '—' }}</td>
+                                <td class="text-center">
+                                  <span class="badge badge-xs"
+                                    :class="{
+                                      'badge-info': p.role === 'S',
+                                      'badge-warning': p.role === 'G',
+                                      'badge-accent': p.role === 'R',
+                                      'badge-ghost': p.role.includes('/') || p.role === '—',
+                                    }"
+                                  >{{ p.role }}</span>
+                                </td>
+                                <td class="text-right font-mono">{{ p.fantasy_points?.toFixed?.(1) ?? p.fantasy_points }}</td>
+                                <td class="text-right">
+                                  <button
+                                    class="btn btn-xs"
+                                    :class="isBlocked(p.hb_human_id) ? 'btn-ghost' : 'btn-error btn-outline'"
+                                    :disabled="blockedToggling[p.hb_human_id]"
+                                    @click="toggleBlocked(l.id, p.hb_human_id)"
+                                  >
+                                    <span v-if="blockedToggling[p.hb_human_id]" class="loading loading-spinner loading-xs"></span>
+                                    {{ isBlocked(p.hb_human_id) ? 'Unblock' : 'Block' }}
+                                  </button>
+                                </td>
+                              </tr>
+                            </tbody>
+                          </table>
+                        </div>
+                      </div>
                     </td>
                   </tr>
                 </template>
@@ -1004,6 +1067,58 @@ function openLeagueEdit(league) {
   editingLeagueId.value = league.id
   // Auto-load seasons if one is already selected so the dropdown shows it
   if (league.hb_league_id) loadHbSeasons(league.hb_league_id)
+  loadBlockedPlayers(league.id)
+}
+
+// ── Draft Block List ────────────────────────────────────────────────────────
+const blockedPool = ref([])
+const blockedList = ref([])
+const blockedLoading = ref(false)
+const blockedError = ref(null)
+const blockedSearch = ref('')
+const blockedToggling = ref({})
+
+const filteredBlockedPool = computed(() => {
+  const q = blockedSearch.value.trim().toLowerCase()
+  if (!q) return blockedPool.value
+  return blockedPool.value.filter(p => (p.name || '').toLowerCase().includes(q))
+})
+
+function isBlocked(hbHumanId) {
+  return blockedList.value.includes(hbHumanId)
+}
+
+async function loadBlockedPlayers(leagueId) {
+  blockedLoading.value = true
+  blockedError.value = null
+  blockedPool.value = []
+  blockedList.value = []
+  blockedSearch.value = ''
+  try {
+    const { data } = await api.get(`/api/admin/fantasy/leagues/${leagueId}/blocked-players`)
+    blockedPool.value = data.pool || []
+    blockedList.value = data.blocked || []
+  } catch (e) {
+    blockedError.value = e.response?.data?.message || e.message
+  } finally {
+    blockedLoading.value = false
+  }
+}
+
+async function toggleBlocked(leagueId, hbHumanId) {
+  const newBlocked = !isBlocked(hbHumanId)
+  blockedToggling.value[hbHumanId] = true
+  try {
+    const { data } = await api.post(`/api/admin/fantasy/leagues/${leagueId}/blocked-players`, {
+      hb_human_id: hbHumanId,
+      blocked: newBlocked,
+    })
+    blockedList.value = data.blocked || []
+  } catch (e) {
+    alert('Failed to toggle block: ' + (e.response?.data?.message || e.message))
+  } finally {
+    blockedToggling.value[hbHumanId] = false
+  }
 }
 
 async function loadHbSeasons(leagueId) {


### PR DESCRIPTION
## Feature: Draft Block List

Admins can now block specific players from being draft-eligible — they won't appear in manual picks and won't be auto-picked on timeout.

## Backend
- `GET /api/admin/fantasy/leagues/<id>/blocked-players` — returns merged pool (skaters+goalies+refs, sorted by FP) + current blocked list
- `POST /api/admin/fantasy/leagues/<id>/blocked-players` — toggles block on/off; stored in `settings["draft_blocked"]` JSONB, **no migration needed**
- Draft service: `blocked_ids` filtered in all eligible pool lookups (queue pick, best-available fallback, force-goalie branch) and `make_pick()` guard

## Admin UI
- New "Draft Block List" panel in the league edit section of AdminView
- Full merged player list with role badge (S/G/R), fantasy points, Block/Unblock button
- Blocked rows styled in red (`bg-error/10`), search input to filter by name

## Testing
Block a player in admin → they should not appear in auto-picks and selecting them manually should fail.
