### PR TITLE
fix: prevent player names from wrapping on mobile in roster list

### DIFF
--- a/frontend/src/views/FantasyLeagueView.vue
+++ b/frontend/src/views/FantasyLeagueView.vue
@@ -680,7 +680,7 @@ const RosterList = {
                 : h('span', { class: 'text-green-400 text-xs font-semibold' }, 'LIVE'),
             ])
           : null
-        const nameCell = h('td', { class: 'pr-4 py-1' }, [
+        const nameCell = h('td', { class: 'pr-4 py-1 whitespace-nowrap' }, [
           h('span', { class: 'text-sm' }, [
             `${icon} `,
             p.jersey_number


### PR DESCRIPTION
Adds `whitespace-nowrap` to the player name cell in RosterList. The table container already has `overflow-x-auto`, so names stay on one line and the table scrolls horizontally on narrow screens (iPhone).