### PR TITLE
fix: hide Refs tab when league has no refs

### DIFF
--- a/frontend/src/views/FantasyLeagueView.vue
+++ b/frontend/src/views/FantasyLeagueView.vue
@@ -743,6 +743,7 @@ const tabs = computed(() => {
   return allTabs.filter(t => {
     if (t.id === 'draft' && isLive) return false
     if (t.id === 'games' && !hasGames) return false
+    if (t.id === 'refs' && !league.value.roster_refs) return false
     return true
   })
 })


### PR DESCRIPTION
Filter out the Refs tab when `league.roster_refs` is 0/null, same pattern as the existing Draft/Games filters.