### PR TITLE
fix: remove Refs tab entirely

### DIFF
--- a/frontend/src/views/FantasyLeagueView.vue
+++ b/frontend/src/views/FantasyLeagueView.vue
@@ -734,7 +734,6 @@ const allTabs = [
   { id: 'myteam', label: '⭐ My Team' },
   { id: 'rosters', label: '👥 Rosters' },
   { id: 'draft', label: '📋 Draft' },
-  { id: 'refs', label: '🎮 Refs' },
 ]
 const tabs = computed(() => {
   if (!league.value) return allTabs
@@ -743,7 +742,6 @@ const tabs = computed(() => {
   return allTabs.filter(t => {
     if (t.id === 'draft' && isLive) return false
     if (t.id === 'games' && !hasGames) return false
-    if (t.id === 'refs' && !league.value.roster_refs) return false
     return true
   })
 })


### PR DESCRIPTION
Rosters tab already shows all player types including refs. No need for a separate Refs tab.