### PR TITLE
feat: migrate status checks to Game.status_id

### DIFF
--- a/app/blueprints/admin.py
+++ b/app/blueprints/admin.py
@@ -19,6 +19,7 @@ import sqlalchemy as sa
 from sqlalchemy import select, func
 
 from hockey_blast_common_lib.merge_humans import merge_humans
+from hockey_blast_common_lib.game_status import StatusId, FINAL_STATUS_IDS
 
 from app.auth.admin_required import require_admin
 from app.db import HBSession, PredSession
@@ -1212,7 +1213,7 @@ def prediction_analysis():
 
     from app.models.game_prediction_log import GamePredictionLog
 
-    FINAL_STATUSES = {"Final", "Final.", "Final/OT", "Final/OT2", "Final/SO", "Final(SO)"}
+
 
     min_skill_diff = request.args.get("min_skill_diff", 0.0, type=float)
     org_id_filter = request.args.get("org_id", None, type=int)
@@ -1262,6 +1263,7 @@ def prediction_analysis():
                 Game.home_final_score,
                 Game.visitor_final_score,
                 Game.status,
+                Game.status_id,
             ).where(Game.id.in_(game_ids))
         ).all()
         for g in hb_games:
@@ -1269,6 +1271,7 @@ def prediction_analysis():
                 "home_final_score": g.home_final_score,
                 "visitor_final_score": g.visitor_final_score,
                 "status": g.status,
+                "status_id": g.status_id,
             }
     except Exception as e:
         logging.getLogger(__name__).warning("Could not fetch HB game results: %s", e)
@@ -1306,7 +1309,7 @@ def prediction_analysis():
         game_res = game_results.get(log.game_id)
         if game_res is None:
             continue
-        if game_res["status"] not in FINAL_STATUSES:
+        if game_res["status_id"] not in FINAL_STATUS_IDS:
             continue
         if game_res["home_final_score"] is None or game_res["visitor_final_score"] is None:
             continue

--- a/app/blueprints/fantasy.py
+++ b/app/blueprints/fantasy.py
@@ -31,7 +31,7 @@ from app.models.fantasy_draft_queue import FantasyDraftQueue
 from app.models.fantasy_standings import FantasyStandings
 from app.models.pred_user import PredUser
 from app.utils.response import error_response
-from hockey_blast_common_lib.game_status import StatusId
+from hockey_blast_common_lib.game_status import StatusId, FINAL_STATUS_IDS
 
 fantasy_bp = Blueprint("fantasy", __name__)
 
@@ -529,8 +529,8 @@ def list_leagues():
         if league.status == "active" and league.hb_division_id:
             try:
                 live_row = hb.execute(
-                    text("SELECT 1 FROM games WHERE division_id = :div_id AND status = 'OPEN' LIMIT 1"),
-                    {"div_id": league.hb_division_id},
+                    text("SELECT 1 FROM games WHERE division_id = :div_id AND status_id = :open_id LIMIT 1"),
+                    {"div_id": league.hb_division_id, "open_id": StatusId.OPEN},
                 ).fetchone()
                 has_live = live_row is not None
             except Exception:
@@ -1051,8 +1051,7 @@ def get_roster(league_id: int, user_id: int):
                 live_games = hb.execute(sa_text(
                     "SELECT id FROM games "
                     f"WHERE division_id IN ({div_ids_sql}) "
-                    "AND status NOT IN ('Final','Final.','Final/OT','Final/OT2','Final/SO',"
-                    "'Final(SO)','CANCELED','FORFEIT','Forfeit','NOEVENTS','FAILED','UnKnown') "
+                    "AND status_id IN (8, 9, 10) "
                     "AND last_update_ts >= :ws"
                 ), {"ws": window_start}).fetchall()
                 if live_games:
@@ -1193,12 +1192,10 @@ def get_league_games(league_id: int):
         return jsonify({"games": []})
 
     hb = HBSession()
-    FINAL = {"Final", "Final.", "Final/OT", "Final/OT2", "Final/SO", "Final(SO)"}
-
     # All games for this division — one fast indexed query
     game_rows = hb.execute(
         text(
-            "SELECT id, game_number, date, time, status, location, game_type, "
+            "SELECT id, game_number, date, time, status, status_id, location, game_type, "
             "home_team_id, visitor_team_id, home_final_score, visitor_final_score "
             "FROM games WHERE division_id = :div_id ORDER BY date ASC, time ASC"
         ),
@@ -1242,7 +1239,7 @@ def get_league_games(league_id: int):
             human_names = {r.id: f"{r.first_name or ''} {r.last_name or ''}".strip() for r in human_rows}
 
     # Batch-load scores for completed games
-    scored_games = {r.id for r in game_rows if r.status in FINAL}
+    scored_games = {r.id for r in game_rows if r.status_id in FINAL_STATUS_IDS}
     my_scores = {}  # game_id -> {hb_human_id -> row}
     if my_roster and scored_games:
         from app.models.fantasy_game_scores import FantasyGameScores
@@ -1291,7 +1288,7 @@ def get_league_games(league_id: int):
     games = []
     for g_row in game_rows:
         my_players = []
-        if my_roster and g_row.status in FINAL:
+        if my_roster and g_row.status_id in FINAL_STATUS_IDS:
             game_score_map = my_scores.get(g_row.id, {})
             for hb_human_id, roster_entry in my_roster.items():
                 sc = game_score_map.get(hb_human_id)

--- a/app/services/result_grader.py
+++ b/app/services/result_grader.py
@@ -18,10 +18,10 @@ from app.db import HBSession, PredSession
 from app.models.pred_pick import PredPick
 from app.models.pred_result import PredResult
 from app.models.pred_league import PredLeague
+from hockey_blast_common_lib.game_status import StatusId, FINAL_STATUS_IDS
 
 
-FINAL_STATUSES = frozenset({"Final", "Final.", "Final/OT", "Final/OT2", "Final/SO", "Final(SO)"})
-VOID_STATUSES = frozenset({"Forfeit", "FORFEIT", "CANCELED", "NOEVENTS"})
+VOID_STATUS_IDS = frozenset({StatusId.FORFEIT, StatusId.CANCELED, StatusId.NOEVENTS})
 UPSET_SCALE = 0.5
 
 
@@ -65,8 +65,8 @@ def grade_completed_games() -> dict:
             summary["skipped"] += 1
             continue
 
-        game_status = getattr(game, "status", None)
-        if game_status not in FINAL_STATUSES | VOID_STATUSES:
+        game_status_id = getattr(game, "status_id", None)
+        if game_status_id not in FINAL_STATUS_IDS | VOID_STATUS_IDS:
             summary["skipped"] += 1
             continue
 
@@ -201,7 +201,7 @@ def _grade_pick(pick: PredPick, game, league: PredLeague | None) -> PredResult:
     )
 
     # Voided game — zero points, pick excluded from accuracy stats
-    if game_status in VOID_STATUSES:
+    if game.status_id in VOID_STATUS_IDS:
         result.is_correct = False
         result.actual_winner_team_id = None
         result.base_points = 0

--- a/app/services/standings_service.py
+++ b/app/services/standings_service.py
@@ -16,7 +16,7 @@ from app.models.pred_pick import PredPick
 from app.models.pred_result import PredResult
 
 
-VOID_STATUSES = frozenset({"Forfeit", "CANCELED"})
+VOID_STATUSES = frozenset({"Forfeit", "FORFEIT", "CANCELED", "NOEVENTS"})
 
 
 def update_standings_for_result(


### PR DESCRIPTION
## Summary
Migrates sportsbook from string-based game status checks to integer `status_id`.

## Depends on
- kletskov/hockey-blast-common-lib#14

## Files changed
- `app/blueprints/fantasy.py` — raw SQL + Python-side checks
- `app/blueprints/admin.py` — game completion check
- `app/services/result_grader.py` — grading logic uses status_id
- `app/services/standings_service.py` — keeps string-based for legacy stored records