### PR TITLE
feat: mid-season player trades for active fantasy leagues

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -61,7 +61,14 @@ def create_app(config_name: str | None = None) -> Flask:
     _register_blueprints(app)
 
     # ── Background scheduler ───────────────────────────────────────────────────
-    if not app.config.get("TESTING"):
+    # DISABLE_SCHEDULER=1 lets dev/worktree runs skip background jobs entirely so
+    # they never mutate shared data (scoring, draft/trade advancement, grading).
+    _scheduler_disabled = os.environ.get("DISABLE_SCHEDULER", "").strip().lower() in ("1", "true", "yes")
+    if _scheduler_disabled:
+        logging.getLogger(__name__).warning(
+            "[init] DISABLE_SCHEDULER set — background jobs will NOT start"
+        )
+    if not app.config.get("TESTING") and not _scheduler_disabled:
         # Start scheduler once per process.
         # - Gunicorn: preload_app=True loads this in master; post_fork shuts it down in workers.
         # - Flask dev server: werkzeug reloader fires twice; only start in the child (WERKZEUG_RUN_MAIN=true).

--- a/app/blueprints/fantasy.py
+++ b/app/blueprints/fantasy.py
@@ -1429,3 +1429,109 @@ def start_season(league_id: int):
             logging.getLogger(__name__).warning("Could not kick off scoring on season start: %s", se)
 
     return jsonify(league.to_dict())
+
+
+# ── Mid-season trades ───────────────────────────────────────────────────────
+
+@fantasy_bp.route("/leagues/<int:league_id>/trade", methods=["GET"])
+@optional_auth
+def get_trade_state(league_id: int):
+    """GET /api/fantasy/leagues/<id>/trade — current trade-round state for this league."""
+    from app.services.fantasy_trade_service import get_round_state
+    viewer_id = g.pred_user.id if g.pred_user else None
+    return jsonify(get_round_state(league_id, viewer_user_id=viewer_id))
+
+
+@fantasy_bp.route("/leagues/<int:league_id>/trade/available", methods=["GET"])
+@optional_auth
+def get_trade_available(league_id: int):
+    """
+    GET /api/fantasy/leagues/<id>/trade/available?type=skater|goalie|ref
+    Available players to acquire (current-season pool minus rostered), with names.
+    """
+    from app.services.fantasy_trade_service import get_available_players
+    of_type = request.args.get("type")
+    if of_type not in (None, "skater", "goalie", "ref"):
+        return error_response("BAD_REQUEST", "type must be skater, goalie, or ref", 400)
+
+    players = get_available_players(league_id, of_type=of_type)
+    # Attach the role-specific fantasy_points for the requested type so the UI
+    # shows a sensible number next to each candidate.
+    fp_key = {
+        "skater": "fantasy_points_skater",
+        "goalie": "fantasy_points_goalie",
+        "ref": "fantasy_points_ref",
+    }.get(of_type, "fantasy_points")
+    result = []
+    for p in players:
+        result.append({
+            "hb_human_id": p["hb_human_id"],
+            "first_name": p.get("first_name"),
+            "last_name": p.get("last_name"),
+            "player_name": f"{p.get('first_name', '')} {p.get('last_name', '')}".strip(),
+            "is_skater": p.get("is_skater", False),
+            "is_goalie": p.get("is_goalie", False),
+            "is_ref": p.get("is_ref", False),
+            "fantasy_points": round(float(p.get(fp_key, 0) or 0), 1),
+        })
+    # Sort by fantasy_points desc for a useful default order.
+    result.sort(key=lambda p: -p["fantasy_points"])
+    return jsonify({"players": result, "type": of_type})
+
+
+@fantasy_bp.route("/leagues/<int:league_id>/trade/initiate", methods=["POST"])
+@require_auth
+def initiate_trade(league_id: int):
+    """POST /api/fantasy/leagues/<id>/trade/initiate — creator starts a trade round."""
+    from app.services.fantasy_trade_service import initiate_trade_round
+    pred = PredSession()
+    user = g.pred_user
+    league = pred.get(FantasyLeague, league_id)
+    if league is None:
+        return error_response("NOT_FOUND", "League not found", 404)
+    if league.created_by != user.id:
+        return error_response("FORBIDDEN", "Only the league creator can start a trade round", 403)
+
+    body = request.get_json(silent=True) or {}
+    pick_hours = body.get("pick_hours", 24)
+    try:
+        rnd = initiate_trade_round(league_id, created_by=user.id, pick_hours=pick_hours)
+    except ValueError as e:
+        return error_response("CONFLICT", str(e), 409)
+    return jsonify(rnd)
+
+
+@fantasy_bp.route("/leagues/<int:league_id>/trade/swap", methods=["POST"])
+@require_auth
+def trade_swap(league_id: int):
+    """
+    POST /api/fantasy/leagues/<id>/trade/swap
+    Body: {"release_hb_human_id": int, "acquire_hb_human_id": int}
+    Execute a one-for-one swap on the caller's turn.
+    """
+    from app.services.fantasy_trade_service import make_trade
+    user = g.pred_user
+    body = request.get_json(silent=True) or {}
+    release_id = body.get("release_hb_human_id")
+    acquire_id = body.get("acquire_hb_human_id")
+    if not isinstance(release_id, int) or not isinstance(acquire_id, int):
+        return error_response("BAD_REQUEST",
+                              "release_hb_human_id and acquire_hb_human_id are required", 400)
+    try:
+        turn = make_trade(league_id, user.id, release_id, acquire_id)
+    except ValueError as e:
+        return error_response("CONFLICT", str(e), 409)
+    return jsonify(turn)
+
+
+@fantasy_bp.route("/leagues/<int:league_id>/trade/skip", methods=["POST"])
+@require_auth
+def trade_skip(league_id: int):
+    """POST /api/fantasy/leagues/<id>/trade/skip — caller keeps their team, ends turn."""
+    from app.services.fantasy_trade_service import skip_turn
+    user = g.pred_user
+    try:
+        turn = skip_turn(league_id, user.id)
+    except ValueError as e:
+        return error_response("CONFLICT", str(e), 409)
+    return jsonify(turn)

--- a/app/jobs/grade_results.py
+++ b/app/jobs/grade_results.py
@@ -242,6 +242,29 @@ def start_scheduler(app):
         replace_existing=True,
     )
 
+    def _trade_advance_job():
+        """
+        Check all active trade rounds for expired turn deadlines and advance them
+        (mark missed, move to next manager, build second-chance pass, complete).
+        Runs every minute so turns progress promptly.
+        """
+        with _app.app_context():
+            try:
+                from app.services.fantasy_trade_service import advance_active_trade_rounds
+                summary = advance_active_trade_rounds()
+                if summary.get("rounds", 0):
+                    logger.debug("[trade] Checked %d active trade round(s)", summary["rounds"])
+            except Exception as exc:
+                logger.exception("[trade] Unhandled error in trade advance job: %s", exc)
+
+    _scheduler.add_job(
+        func=_trade_advance_job,
+        trigger=IntervalTrigger(minutes=1),
+        id="advance_trades",
+        name="Advance fantasy trade turns on deadline",
+        replace_existing=True,
+    )
+
 
     def _fantasy_score_job():
         """Score completed games for all active fantasy leagues."""

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -28,6 +28,8 @@ from app.models.fantasy_draft_queue import FantasyDraftQueue
 from app.models.fantasy_manager_queue import FantasyManagerQueue
 from app.models.fantasy_game_scores import FantasyGameScores
 from app.models.fantasy_standings import FantasyStandings
+from app.models.fantasy_trade_round import FantasyTradeRound
+from app.models.fantasy_trade_turn import FantasyTradeTurn
 from app.models.game_prediction_log import GamePredictionLog
 
 __all__ = [
@@ -55,5 +57,7 @@ __all__ = [
     "FantasyManagerQueue",
     "FantasyGameScores",
     "FantasyStandings",
+    "FantasyTradeRound",
+    "FantasyTradeTurn",
     "GamePredictionLog",
 ]

--- a/app/models/fantasy_trade_round.py
+++ b/app/models/fantasy_trade_round.py
@@ -1,0 +1,67 @@
+"""
+FantasyTradeRound — a mid-season trade round for an active fantasy league.
+
+The league creator initiates a round. Managers take turns in ascending fantasy-
+points order (lowest FP goes first). On their turn a manager may release one
+player and acquire one available player of the SAME type (skater/goalie/ref), or
+skip. Managers who miss their turn get a second-chance pass (round-robin) after
+everyone else has gone; then the round completes.
+"""
+
+from datetime import datetime, timezone
+
+import sqlalchemy as sa
+from sqlalchemy import DateTime, Integer, String
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.db import PredBase
+
+# Status values
+TRADE_ROUND_ACTIVE = "active"
+TRADE_ROUND_COMPLETED = "completed"
+TRADE_ROUND_CANCELED = "canceled"
+
+
+class FantasyTradeRound(PredBase):
+    __tablename__ = "fantasy_trade_rounds"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    league_id: Mapped[int] = mapped_column(
+        Integer, sa.ForeignKey("fantasy_leagues.id"), nullable=False
+    )
+    status: Mapped[str] = mapped_column(String(20), nullable=False, default=TRADE_ROUND_ACTIVE)
+    # Per-turn time window in hours (defaults to 24 like the draft).
+    pick_hours: Mapped[int] = mapped_column(Integer, nullable=False, default=24)
+    created_by: Mapped[int | None] = mapped_column(
+        Integer, sa.ForeignKey("pred_users.id"), nullable=True
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        nullable=False,
+    )
+    completed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
+    # Relationships
+    league: Mapped["FantasyLeague"] = relationship("FantasyLeague")
+    turns: Mapped[list["FantasyTradeTurn"]] = relationship(
+        "FantasyTradeTurn", back_populates="round", lazy="dynamic"
+    )
+
+    def to_dict(self) -> dict:
+        return {
+            "id": self.id,
+            "league_id": self.league_id,
+            "status": self.status,
+            "pick_hours": self.pick_hours,
+            "created_by": self.created_by,
+            "created_at": self.created_at.isoformat() if self.created_at else None,
+            "completed_at": self.completed_at.isoformat() if self.completed_at else None,
+        }
+
+    def __repr__(self) -> str:
+        return f"<FantasyTradeRound id={self.id} league_id={self.league_id} status={self.status!r}>"
+
+
+from app.models.fantasy_league import FantasyLeague  # noqa: E402
+from app.models.fantasy_trade_turn import FantasyTradeTurn  # noqa: E402

--- a/app/models/fantasy_trade_turn.py
+++ b/app/models/fantasy_trade_turn.py
@@ -1,0 +1,95 @@
+"""
+FantasyTradeTurn — one manager's turn within a trade round.
+
+Turns are ordered by `turn_order` (ascending fantasy points → lowest FP first).
+`pass_number` distinguishes the first pass (1) from the second-chance round-robin
+pass (2) offered to managers who missed their first turn.
+
+A turn resolves in one of three ways:
+  - completed (made a swap): released_hb_human_id + acquired_hb_human_id set, acted_at set
+  - skipped (chose to keep team): is_skipped=True, acted_at set
+  - missed (deadline passed): is_missed=True (eligible for a pass-2 second chance)
+
+Exactly one swap per turn (release one, acquire one of the same type).
+"""
+
+from datetime import datetime, timezone
+
+import sqlalchemy as sa
+from sqlalchemy import Boolean, DateTime, Integer, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.db import PredBase
+
+
+class FantasyTradeTurn(PredBase):
+    __tablename__ = "fantasy_trade_turns"
+    __table_args__ = (
+        UniqueConstraint(
+            "round_id", "user_id", "pass_number",
+            name="uq_fantasy_trade_turns_round_user_pass",
+        ),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    round_id: Mapped[int] = mapped_column(
+        Integer, sa.ForeignKey("fantasy_trade_rounds.id"), nullable=False
+    )
+    league_id: Mapped[int] = mapped_column(Integer, nullable=False)
+    user_id: Mapped[int] = mapped_column(
+        Integer, sa.ForeignKey("pred_users.id"), nullable=False
+    )
+    # Position within the round; pass 1 = FP order, pass 2 = second chance for missers.
+    turn_order: Mapped[int] = mapped_column(Integer, nullable=False)
+    pass_number: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
+
+    # Outcome
+    released_hb_human_id: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    acquired_hb_human_id: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    is_skipped: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    is_missed: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+
+    deadline: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    acted_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        nullable=False,
+    )
+
+    # Relationships
+    round: Mapped["FantasyTradeRound"] = relationship(
+        "FantasyTradeRound", back_populates="turns"
+    )
+
+    @property
+    def is_resolved(self) -> bool:
+        """A turn is resolved once the manager acted, skipped, or missed it."""
+        return bool(self.acted_at) or self.is_skipped or self.is_missed
+
+    def to_dict(self) -> dict:
+        return {
+            "id": self.id,
+            "round_id": self.round_id,
+            "league_id": self.league_id,
+            "user_id": self.user_id,
+            "turn_order": self.turn_order,
+            "pass_number": self.pass_number,
+            "released_hb_human_id": self.released_hb_human_id,
+            "acquired_hb_human_id": self.acquired_hb_human_id,
+            "is_skipped": self.is_skipped,
+            "is_missed": self.is_missed,
+            "is_resolved": self.is_resolved,
+            "deadline": self.deadline.isoformat() if self.deadline else None,
+            "acted_at": self.acted_at.isoformat() if self.acted_at else None,
+            "created_at": self.created_at.isoformat() if self.created_at else None,
+        }
+
+    def __repr__(self) -> str:
+        return (
+            f"<FantasyTradeTurn id={self.id} round={self.round_id} "
+            f"user={self.user_id} pass={self.pass_number} order={self.turn_order}>"
+        )
+
+
+from app.models.fantasy_trade_round import FantasyTradeRound  # noqa: E402

--- a/app/services/fantasy_trade_service.py
+++ b/app/services/fantasy_trade_service.py
@@ -262,13 +262,87 @@ def advance_trade_round(round_id: int) -> None:
     if current.deadline and current.deadline > now:
         return  # still on the clock
 
-    # Deadline passed — mark missed (pass-1 missers get a pass-2 second chance).
+    # Deadline passed. First try to auto-trade on the manager's behalf: if they
+    # have a dead-weight skater (0 fantasy points), swap it for the best available
+    # skater. If that succeeds the turn auto-completes; otherwise mark it missed
+    # (pass-1 missers still get a pass-2 second chance).
+    if _try_auto_trade_for_expired_turn(league_id=rnd.league_id, round_id=round_id,
+                                        turn=current, pred=pred):
+        return  # make_trade already advanced to the next turn
+
     current.is_missed = True
     current.acted_at = None
     pred.commit()
     logger.info("[trade] round=%d user=%d missed turn (pass %d)",
                 round_id, current.user_id, current.pass_number)
     _activate_next_turn(round_id, pred)
+
+
+def _try_auto_trade_for_expired_turn(league_id: int, round_id: int, turn, pred) -> bool:
+    """
+    Auto-trade for a manager whose turn expired: if they hold a skater with zero
+    fantasy points, release it and acquire the highest-scoring available skater —
+    but only when that's a real upgrade (the acquired skater has > 0 points).
+
+    Returns True if an auto-trade was performed (turn is now complete), else False
+    (caller falls back to marking the turn missed). Notifies the manager like the
+    auto-draft flow does.
+    """
+    user_id = turn.user_id
+
+    # Skaters on this manager's roster (exclude goalies/refs).
+    roster_skaters = pred.execute(
+        select(FantasyRoster.hb_human_id).where(
+            FantasyRoster.league_id == league_id,
+            FantasyRoster.user_id == user_id,
+            FantasyRoster.is_goalie == False,  # noqa: E712
+            FantasyRoster.is_ref == False,  # noqa: E712
+        )
+    ).scalars().all()
+    if not roster_skaters:
+        return False
+
+    # Total fantasy points each rostered skater has earned in this league.
+    pts_rows = pred.execute(
+        select(
+            FantasyGameScores.hb_human_id,
+            func.coalesce(func.sum(FantasyGameScores.points), 0).label("pts"),
+        )
+        .where(
+            FantasyGameScores.league_id == league_id,
+            FantasyGameScores.hb_human_id.in_(roster_skaters),
+        )
+        .group_by(FantasyGameScores.hb_human_id)
+    ).all()
+    pts_map = {r.hb_human_id: float(r.pts or 0) for r in pts_rows}
+
+    # Zero-point skaters (includes skaters with no score rows at all). Deterministic
+    # release pick: lowest hb_human_id among them.
+    zero_skaters = sorted(h for h in roster_skaters if pts_map.get(h, 0.0) == 0.0)
+    if not zero_skaters:
+        return False
+    release_id = zero_skaters[0]
+
+    # Best available skater by fantasy points.
+    available = get_available_players(league_id, of_type="skater")
+    if not available:
+        return False
+    best = max(available, key=lambda p: float(p.get("fantasy_points_skater", 0) or 0))
+    if float(best.get("fantasy_points_skater", 0) or 0) <= 0:
+        return False  # no upgrade available — leave the turn to be marked missed
+    acquire_id = best["hb_human_id"]
+
+    try:
+        make_trade(league_id, user_id, release_id, acquire_id)
+    except ValueError as e:
+        logger.warning("[trade] auto-trade failed for league=%d user=%d: %s",
+                       league_id, user_id, e)
+        return False
+
+    logger.info("[trade] round=%d user=%d AUTO-traded release=%d acquire=%d",
+                round_id, user_id, release_id, acquire_id)
+    _notify_auto_trade(user_id, league_id, release_id, acquire_id, pred)
+    return True
 
 
 def advance_active_trade_rounds() -> dict:
@@ -647,3 +721,50 @@ def _notify_turn(user_id: int, league_id: int, deadline, pred) -> None:
         pred.commit()
     except Exception as e:
         logger.warning("[trade] could not notify user=%d: %s", user_id, e)
+
+
+def _hb_player_name(hb_human_id: int) -> str:
+    """Best-effort 'First Last' for a HB human id (for notifications)."""
+    try:
+        from app.db import HBSession
+        from sqlalchemy import text as sa_text
+        row = HBSession().execute(
+            sa_text("SELECT first_name, last_name FROM humans WHERE id = :hid"),
+            {"hid": hb_human_id},
+        ).fetchone()
+        if row:
+            return f"{row.first_name or ''} {row.last_name or ''}".strip() or f"#{hb_human_id}"
+    except Exception:
+        pass
+    return f"#{hb_human_id}"
+
+
+def _notify_auto_trade(user_id: int, league_id: int, release_hb_human_id: int,
+                       acquire_hb_human_id: int, pred) -> None:
+    """
+    Notify a manager that we auto-traded for them after their turn expired
+    (mirrors the auto-draft notification: fires immediately, delay=0).
+    """
+    try:
+        from app.services.notify_service import notify_user
+        league_name = ""
+        try:
+            lg = pred.get(FantasyLeague, league_id)
+            if lg:
+                league_name = f" · {lg.name}"
+        except Exception:
+            pass
+        dropped = _hb_player_name(release_hb_human_id)
+        added = _hb_player_name(acquire_hb_human_id)
+        notify_user(
+            db=pred,
+            user_id=user_id,
+            title=f"🔁 Auto-traded for you!{league_name}",
+            body=f"Your turn expired — dropped {dropped} (0 pts) for {added}.",
+            url=f"/fantasy/{league_id}?tab=trade",
+            notif_type="fantasy_trade",
+            delay_seconds=0,  # immediate — they missed their turn
+        )
+        pred.commit()
+    except Exception as e:
+        logger.warning("[trade] could not notify auto-trade for user=%d: %s", user_id, e)

--- a/app/services/fantasy_trade_service.py
+++ b/app/services/fantasy_trade_service.py
@@ -278,60 +278,82 @@ def advance_trade_round(round_id: int) -> None:
     _activate_next_turn(round_id, pred)
 
 
+# Role → the pool's role-specific fantasy-points key (what the acquired player adds).
+_ROLE_FP_KEY = {
+    "skater": "fantasy_points_skater",
+    "goalie": "fantasy_points_goalie",
+    "ref": "fantasy_points_ref",
+}
+
+
 def _try_auto_trade_for_expired_turn(league_id: int, round_id: int, turn, pred) -> bool:
     """
-    Auto-trade for a manager whose turn expired: if they hold a skater with zero
-    fantasy points, release it and acquire the highest-scoring available skater —
-    but only when that's a real upgrade (the acquired skater has > 0 points).
+    Auto-trade for a manager whose turn expired: if they hold any player with zero
+    fantasy points, release it and acquire the best available replacement OF THE
+    SAME ROLE (skater→skater, goalie→goalie, ref→ref).
 
-    Returns True if an auto-trade was performed (turn is now complete), else False
-    (caller falls back to marking the turn missed). Notifies the manager like the
-    auto-draft flow does.
+    Because releasing a zero-point player adds exactly the acquired player's
+    points, we evaluate every role the manager has a zero-point player in and pick
+    the single swap that ADDS THE MOST POINTS overall. Only performed when it's a
+    real upgrade (acquired player has > 0 points).
+
+    Returns True if an auto-trade was performed (turn complete), else False (caller
+    marks the turn missed). Notifies the manager like the auto-draft flow.
     """
     user_id = turn.user_id
 
-    # Skaters on this manager's roster (exclude goalies/refs).
-    roster_skaters = pred.execute(
-        select(FantasyRoster.hb_human_id).where(
-            FantasyRoster.league_id == league_id,
-            FantasyRoster.user_id == user_id,
-            FantasyRoster.is_goalie == False,  # noqa: E712
-            FantasyRoster.is_ref == False,  # noqa: E712
-        )
-    ).scalars().all()
-    if not roster_skaters:
+    # This manager's roster with role flags.
+    roster = pred.execute(
+        select(FantasyRoster.hb_human_id, FantasyRoster.is_goalie, FantasyRoster.is_ref)
+        .where(FantasyRoster.league_id == league_id, FantasyRoster.user_id == user_id)
+    ).all()
+    if not roster:
         return False
 
-    # Total fantasy points each rostered skater has earned in this league.
+    # Points each rostered player has earned in this league.
+    ids = [r.hb_human_id for r in roster]
     pts_rows = pred.execute(
         select(
             FantasyGameScores.hb_human_id,
             func.coalesce(func.sum(FantasyGameScores.points), 0).label("pts"),
         )
-        .where(
-            FantasyGameScores.league_id == league_id,
-            FantasyGameScores.hb_human_id.in_(roster_skaters),
-        )
+        .where(FantasyGameScores.league_id == league_id, FantasyGameScores.hb_human_id.in_(ids))
         .group_by(FantasyGameScores.hb_human_id)
     ).all()
     pts_map = {r.hb_human_id: float(r.pts or 0) for r in pts_rows}
 
-    # Zero-point skaters (includes skaters with no score rows at all). Deterministic
-    # release pick: lowest hb_human_id among them.
-    zero_skaters = sorted(h for h in roster_skaters if pts_map.get(h, 0.0) == 0.0)
-    if not zero_skaters:
+    # Zero-point players grouped by role. Deterministic release pick per role:
+    # lowest hb_human_id.
+    zero_by_role: dict[str, int] = {}
+    for r in roster:
+        if pts_map.get(r.hb_human_id, 0.0) != 0.0:
+            continue
+        role = _player_type(r.is_goalie, r.is_ref)
+        if role not in zero_by_role or r.hb_human_id < zero_by_role[role]:
+            zero_by_role[role] = r.hb_human_id
+    if not zero_by_role:
         return False
-    release_id = zero_skaters[0]
 
-    # Best available skater by fantasy points.
-    available = get_available_players(league_id, of_type="skater")
-    if not available:
-        return False
-    best = max(available, key=lambda p: float(p.get("fantasy_points_skater", 0) or 0))
-    if float(best.get("fantasy_points_skater", 0) or 0) <= 0:
-        return False  # no upgrade available — leave the turn to be marked missed
-    acquire_id = best["hb_human_id"]
+    # For each role with a zero-point player, find the best available replacement
+    # of that role; keep the swap that adds the most points overall.
+    best_swap = None  # (points_added, release_id, acquire_id, role, acquire_name)
+    for role, release_id in zero_by_role.items():
+        available = get_available_players(league_id, of_type=role)
+        if not available:
+            continue
+        fp_key = _ROLE_FP_KEY[role]
+        cand = max(available, key=lambda p: float(p.get(fp_key, 0) or 0))
+        gain = float(cand.get(fp_key, 0) or 0)
+        if gain <= 0:
+            continue  # no upgrade for this role
+        if best_swap is None or gain > best_swap[0]:
+            name = f"{cand.get('first_name', '')} {cand.get('last_name', '')}".strip()
+            best_swap = (gain, release_id, cand["hb_human_id"], role, name)
 
+    if best_swap is None:
+        return False  # no positive-scoring replacement in any role — mark missed
+
+    _gain, release_id, acquire_id, role, _name = best_swap
     try:
         make_trade(league_id, user_id, release_id, acquire_id)
     except ValueError as e:
@@ -339,8 +361,8 @@ def _try_auto_trade_for_expired_turn(league_id: int, round_id: int, turn, pred) 
                        league_id, user_id, e)
         return False
 
-    logger.info("[trade] round=%d user=%d AUTO-traded release=%d acquire=%d",
-                round_id, user_id, release_id, acquire_id)
+    logger.info("[trade] round=%d user=%d AUTO-traded (%s) release=%d acquire=%d (+%.1f pts)",
+                round_id, user_id, role, release_id, acquire_id, _gain)
     _notify_auto_trade(user_id, league_id, release_id, acquire_id, pred)
     return True
 

--- a/app/services/fantasy_trade_service.py
+++ b/app/services/fantasy_trade_service.py
@@ -1,0 +1,649 @@
+"""
+fantasy_trade_service — manages mid-season trade rounds for active leagues.
+
+Flow:
+  1. League creator initiates a round (initiate_trade_round).
+  2. Turn order = managers by ascending fantasy points (lowest FP goes first).
+  3. On their turn a manager either:
+       - swaps: release one rostered player, acquire one available player of the
+         SAME type (skater/goalie/ref)  → make_trade()
+       - skips: keep their team                                  → skip_turn()
+       - misses: deadline passes; advance_trade_round() marks them missed and
+         moves on. Missed managers get a SECOND pass (round-robin) after everyone
+         else has gone in pass 1.
+  4. When pass-1 and pass-2 turns are all resolved, the round completes.
+
+Point attribution: FULL REATTRIBUTION. When a player is traded, all of their
+existing fantasy_game_scores rows in this league are reassigned to the new owner,
+so the new owner gets the player's entire season production and standings
+recompute on the fly.
+
+"Available" players = current-season-eligible (league.hb_season_id) players who
+are NOT currently on any roster in this league. This naturally includes both
+players who newly appeared this season and players released earlier in the round.
+"""
+
+import logging
+from datetime import datetime, timezone, timedelta
+
+from sqlalchemy import select, func
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+
+from app.db import PredSession
+from app.models.fantasy_league import FantasyLeague
+from app.models.fantasy_manager import FantasyManager
+from app.models.fantasy_roster import FantasyRoster
+from app.models.fantasy_game_scores import FantasyGameScores
+from app.models.fantasy_trade_round import (
+    FantasyTradeRound,
+    TRADE_ROUND_ACTIVE,
+    TRADE_ROUND_COMPLETED,
+)
+from app.models.fantasy_trade_turn import FantasyTradeTurn
+
+logger = logging.getLogger(__name__)
+
+
+# ── Round lifecycle ────────────────────────────────────────────────────────────
+
+def initiate_trade_round(league_id: int, created_by: int, pick_hours: int = 24) -> dict:
+    """
+    Create a new trade round for an active league and build pass-1 turns in
+    ascending fantasy-points order (lowest FP first). Sets the deadline on the
+    first turn and notifies that manager.
+
+    Raises ValueError on validation failure.
+    """
+    pred = PredSession()
+    league = pred.get(FantasyLeague, league_id)
+    if league is None:
+        raise ValueError("League not found")
+    if league.status != "active":
+        raise ValueError(f"Trades are only allowed while the league is active (status={league.status})")
+
+    # Only one open round at a time.
+    existing = pred.execute(
+        select(FantasyTradeRound).where(
+            FantasyTradeRound.league_id == league_id,
+            FantasyTradeRound.status == TRADE_ROUND_ACTIVE,
+        )
+    ).scalar_one_or_none()
+    if existing is not None:
+        raise ValueError("A trade round is already in progress for this league")
+
+    managers = pred.execute(
+        select(FantasyManager).where(FantasyManager.league_id == league_id)
+    ).scalars().all()
+    if len(managers) < 2:
+        raise ValueError("Need at least 2 managers to run a trade round")
+
+    rnd = FantasyTradeRound(
+        league_id=league_id,
+        status=TRADE_ROUND_ACTIVE,
+        pick_hours=max(1, int(pick_hours or 24)),
+        created_by=created_by,
+        created_at=datetime.now(timezone.utc),
+    )
+    pred.add(rnd)
+    pred.commit()
+
+    # Turn order: ascending fantasy points (lowest first). Managers with no
+    # standings row count as 0 points (they go first, ties broken by user_id).
+    ordered_user_ids = _managers_by_ascending_fp(league_id, managers, pred)
+
+    turns = []
+    for order, user_id in enumerate(ordered_user_ids, 1):
+        turns.append({
+            "round_id": rnd.id,
+            "league_id": league_id,
+            "user_id": user_id,
+            "turn_order": order,
+            "pass_number": 1,
+        })
+    pred.execute(pg_insert(FantasyTradeTurn).values(turns).on_conflict_do_nothing())
+    pred.commit()
+
+    _activate_next_turn(rnd.id, pred)
+    return rnd.to_dict()
+
+
+def _managers_by_ascending_fp(league_id: int, managers, pred) -> list[int]:
+    """Return manager user_ids ordered by ascending total fantasy points."""
+    from app.models.fantasy_standings import FantasyStandings
+    standings = pred.execute(
+        select(FantasyStandings.user_id, FantasyStandings.total_points)
+        .where(FantasyStandings.league_id == league_id)
+    ).all()
+    fp_map = {r.user_id: float(r.total_points or 0) for r in standings}
+    # lowest FP first; stable tiebreak by user_id for determinism
+    return sorted(
+        (m.user_id for m in managers),
+        key=lambda uid: (fp_map.get(uid, 0.0), uid),
+    )
+
+
+def _current_turn(round_id: int, pred):
+    """Return the active (deadline-set, unresolved) turn for a round, or None."""
+    return pred.execute(
+        select(FantasyTradeTurn)
+        .where(
+            FantasyTradeTurn.round_id == round_id,
+            FantasyTradeTurn.deadline.is_not(None),
+            FantasyTradeTurn.acted_at.is_(None),
+            FantasyTradeTurn.is_skipped == False,  # noqa: E712
+            FantasyTradeTurn.is_missed == False,  # noqa: E712
+        )
+        .order_by(FantasyTradeTurn.pass_number.asc(), FantasyTradeTurn.turn_order.asc())
+        .limit(1)
+    ).scalar_one_or_none()
+
+
+def _activate_next_turn(round_id: int, pred) -> None:
+    """
+    Find the next unresolved turn with no deadline yet, set its deadline, and
+    notify the manager. If pass 1 is exhausted, build pass 2 (second chance) for
+    managers who missed pass 1. If nothing remains, complete the round.
+    """
+    rnd = pred.get(FantasyTradeRound, round_id)
+    if rnd is None or rnd.status != TRADE_ROUND_ACTIVE:
+        return
+
+    # If a turn is already active, do nothing (someone is on the clock).
+    if _current_turn(round_id, pred) is not None:
+        return
+
+    nxt = _next_unstarted_turn(round_id, pred)
+    if nxt is None:
+        # Pass 1 (and any existing pass 2) exhausted. Try to build pass 2.
+        if not _build_second_chance_pass(round_id, pred):
+            _complete_round(round_id, pred)
+            return
+        nxt = _next_unstarted_turn(round_id, pred)
+        if nxt is None:
+            _complete_round(round_id, pred)
+            return
+
+    nxt.deadline = datetime.now(timezone.utc) + timedelta(hours=rnd.pick_hours)
+    pred.commit()
+    _notify_turn(nxt.user_id, rnd.league_id, nxt.deadline, pred)
+
+
+def _next_unstarted_turn(round_id: int, pred):
+    """Next turn that has not been given a deadline and is not resolved."""
+    return pred.execute(
+        select(FantasyTradeTurn)
+        .where(
+            FantasyTradeTurn.round_id == round_id,
+            FantasyTradeTurn.deadline.is_(None),
+            FantasyTradeTurn.acted_at.is_(None),
+            FantasyTradeTurn.is_skipped == False,  # noqa: E712
+            FantasyTradeTurn.is_missed == False,  # noqa: E712
+        )
+        .order_by(FantasyTradeTurn.pass_number.asc(), FantasyTradeTurn.turn_order.asc())
+        .limit(1)
+    ).scalar_one_or_none()
+
+
+def _build_second_chance_pass(round_id: int, pred) -> bool:
+    """
+    Create pass-2 turns for managers who MISSED their pass-1 turn (round-robin
+    second chance). Returns True if any were created. Idempotent: won't duplicate
+    pass-2 turns that already exist.
+    """
+    missed = pred.execute(
+        select(FantasyTradeTurn)
+        .where(
+            FantasyTradeTurn.round_id == round_id,
+            FantasyTradeTurn.pass_number == 1,
+            FantasyTradeTurn.is_missed == True,  # noqa: E712
+        )
+        .order_by(FantasyTradeTurn.turn_order.asc())
+    ).scalars().all()
+    if not missed:
+        return False
+
+    already = {
+        t.user_id
+        for t in pred.execute(
+            select(FantasyTradeTurn).where(
+                FantasyTradeTurn.round_id == round_id,
+                FantasyTradeTurn.pass_number == 2,
+            )
+        ).scalars().all()
+    }
+
+    new_turns = []
+    order = 1
+    for t in missed:
+        if t.user_id in already:
+            continue
+        new_turns.append({
+            "round_id": round_id,
+            "league_id": t.league_id,
+            "user_id": t.user_id,
+            "turn_order": order,
+            "pass_number": 2,
+        })
+        order += 1
+
+    if not new_turns:
+        return False
+    pred.execute(pg_insert(FantasyTradeTurn).values(new_turns).on_conflict_do_nothing())
+    pred.commit()
+    logger.info("[trade] round=%d built second-chance pass for %d managers", round_id, len(new_turns))
+    return True
+
+
+def _complete_round(round_id: int, pred) -> None:
+    rnd = pred.get(FantasyTradeRound, round_id)
+    if rnd and rnd.status == TRADE_ROUND_ACTIVE:
+        rnd.status = TRADE_ROUND_COMPLETED
+        rnd.completed_at = datetime.now(timezone.utc)
+        pred.commit()
+        logger.info("[trade] round=%d completed", round_id)
+
+
+def advance_trade_round(round_id: int) -> None:
+    """
+    Background-job entrypoint: if the current turn's deadline has passed, mark it
+    missed and activate the next turn. Safe to call repeatedly.
+    """
+    pred = PredSession()
+    rnd = pred.get(FantasyTradeRound, round_id)
+    if rnd is None or rnd.status != TRADE_ROUND_ACTIVE:
+        return
+
+    now = datetime.now(timezone.utc)
+    current = _current_turn(round_id, pred)
+    if current is None:
+        # No active turn — try to advance (e.g. round just created, or stalled).
+        _activate_next_turn(round_id, pred)
+        return
+    if current.deadline and current.deadline > now:
+        return  # still on the clock
+
+    # Deadline passed — mark missed (pass-1 missers get a pass-2 second chance).
+    current.is_missed = True
+    current.acted_at = None
+    pred.commit()
+    logger.info("[trade] round=%d user=%d missed turn (pass %d)",
+                round_id, current.user_id, current.pass_number)
+    _activate_next_turn(round_id, pred)
+
+
+def advance_active_trade_rounds() -> dict:
+    """Scheduler hook: advance every active trade round. Returns a summary."""
+    pred = PredSession()
+    summary = {"rounds": 0, "advanced": 0}
+    rounds = pred.execute(
+        select(FantasyTradeRound).where(FantasyTradeRound.status == TRADE_ROUND_ACTIVE)
+    ).scalars().all()
+    for rnd in rounds:
+        summary["rounds"] += 1
+        try:
+            advance_trade_round(rnd.id)
+            summary["advanced"] += 1
+        except Exception as e:
+            logger.warning("[trade] advance failed for round=%d: %s", rnd.id, e)
+    return summary
+
+
+# ── Manager actions ──────────────────────────────────────────────────────────
+
+def make_trade(league_id: int, user_id: int, release_hb_human_id: int,
+               acquire_hb_human_id: int) -> dict:
+    """
+    Execute a one-for-one swap on the calling manager's turn:
+      - release `release_hb_human_id` (must be on the manager's roster)
+      - acquire `acquire_hb_human_id` (must be available + same type as released)
+    Reattributes the acquired player's existing scores to the new owner and
+    recomputes standings. Ends the manager's turn.
+
+    Raises ValueError on validation failure.
+    """
+    pred = PredSession()
+    league = pred.get(FantasyLeague, league_id)
+    if league is None:
+        raise ValueError("League not found")
+
+    rnd = _active_round(league_id, pred)
+    if rnd is None:
+        raise ValueError("No trade round is in progress")
+
+    current = _current_turn(rnd.id, pred)
+    if current is None:
+        raise ValueError("No active turn right now")
+    if current.user_id != user_id:
+        raise ValueError("It is not your turn to trade")
+
+    # Released player must be on this manager's roster.
+    released = pred.execute(
+        select(FantasyRoster).where(
+            FantasyRoster.league_id == league_id,
+            FantasyRoster.user_id == user_id,
+            FantasyRoster.hb_human_id == release_hb_human_id,
+        )
+    ).scalar_one_or_none()
+    if released is None:
+        raise ValueError("You can only release a player on your own roster")
+
+    # No-op swap (release == acquire) is treated as a skip.
+    if release_hb_human_id == acquire_hb_human_id:
+        return skip_turn(league_id, user_id)
+
+    # Acquired player must NOT currently be on any roster in this league.
+    taken = pred.execute(
+        select(FantasyRoster).where(
+            FantasyRoster.league_id == league_id,
+            FantasyRoster.hb_human_id == acquire_hb_human_id,
+        )
+    ).scalar_one_or_none()
+    if taken is not None:
+        raise ValueError("That player is already on a team in this league")
+
+    # Acquired player must be available + the SAME type as the released player.
+    released_type = _player_type(released.is_goalie, released.is_ref)
+    available = get_available_players(league_id, of_type=released_type)
+    cand = next((p for p in available if p["hb_human_id"] == acquire_hb_human_id), None)
+    if cand is None:
+        raise ValueError(
+            f"That player is not available as a {released_type} this season"
+        )
+
+    now = datetime.now(timezone.utc)
+
+    # Swap the roster row: keep the row, change identity + role flags + provenance.
+    released.hb_human_id = acquire_hb_human_id
+    released.is_goalie = released_type == "goalie"
+    released.is_ref = released_type == "ref"
+    released.round_picked = None
+    released.pick_number = None
+    released.drafted_at = now
+    pred.commit()
+
+    # FULL REATTRIBUTION: any existing scores for the acquired player in this
+    # league now belong to the new owner. (Released player's past scores stay as
+    # historical rows but are no longer on anyone's roster, so they drop out of
+    # team totals — see recompute_standings, which sums by current ownership.)
+    _reassign_player_scores(league_id, acquire_hb_human_id, user_id, pred)
+
+    # Record the turn outcome.
+    current.released_hb_human_id = release_hb_human_id
+    current.acquired_hb_human_id = acquire_hb_human_id
+    current.acted_at = now
+    pred.commit()
+
+    recompute_standings(league_id, pred)
+    _activate_next_turn(rnd.id, pred)
+
+    logger.info("[trade] league=%d user=%d released=%d acquired=%d",
+                league_id, user_id, release_hb_human_id, acquire_hb_human_id)
+    return current.to_dict()
+
+
+def skip_turn(league_id: int, user_id: int) -> dict:
+    """Manager keeps their team and ends their turn."""
+    pred = PredSession()
+    rnd = _active_round(league_id, pred)
+    if rnd is None:
+        raise ValueError("No trade round is in progress")
+
+    current = _current_turn(rnd.id, pred)
+    if current is None:
+        raise ValueError("No active turn right now")
+    if current.user_id != user_id:
+        raise ValueError("It is not your turn to trade")
+
+    current.is_skipped = True
+    current.acted_at = datetime.now(timezone.utc)
+    pred.commit()
+    logger.info("[trade] league=%d user=%d skipped", league_id, user_id)
+    _activate_next_turn(rnd.id, pred)
+    return current.to_dict()
+
+
+# ── Queries / helpers ──────────────────────────────────────────────────────────
+
+def _active_round(league_id: int, pred):
+    return pred.execute(
+        select(FantasyTradeRound).where(
+            FantasyTradeRound.league_id == league_id,
+            FantasyTradeRound.status == TRADE_ROUND_ACTIVE,
+        )
+    ).scalar_one_or_none()
+
+
+def _player_type(is_goalie: bool, is_ref: bool) -> str:
+    if is_goalie:
+        return "goalie"
+    if is_ref:
+        return "ref"
+    return "skater"
+
+
+def get_available_players(league_id: int, of_type: str | None = None) -> list[dict]:
+    """
+    Players eligible to be acquired: current-season pool (league.hb_season_id)
+    minus everyone currently rostered in this league. Optionally filter to a
+    single type ('skater' | 'goalie' | 'ref').
+    """
+    from app.services.fantasy_pool_service import get_player_pool
+    pred = PredSession()
+    league = pred.get(FantasyLeague, league_id)
+    if league is None:
+        return []
+
+    pool = get_player_pool(
+        league.level_id,
+        org_id=league.org_id,
+        league_id=league.hb_league_id,
+        # CURRENT season (play season), NOT draft_season_id — this is the key
+        # difference from the draft pool: new this-season players become available.
+        season_id=league.hb_season_id,
+        min_games=league.min_games_played or 1,
+    )
+
+    rostered = set(pred.execute(
+        select(FantasyRoster.hb_human_id).where(FantasyRoster.league_id == league_id)
+    ).scalars().all())
+
+    if of_type == "goalie":
+        candidates = pool["goalies"]
+    elif of_type == "ref":
+        candidates = pool.get("refs", [])
+    elif of_type == "skater":
+        candidates = pool["skaters"]
+    else:
+        candidates = pool["players"]
+
+    return [p for p in candidates if p["hb_human_id"] not in rostered]
+
+
+def _reassign_player_scores(league_id: int, hb_human_id: int, new_user_id: int, pred) -> None:
+    """Reattribute all of a player's scores in this league to the new owner."""
+    pred.execute(
+        FantasyGameScores.__table__.update()
+        .where(
+            FantasyGameScores.league_id == league_id,
+            FantasyGameScores.hb_human_id == hb_human_id,
+        )
+        .values(user_id=new_user_id)
+    )
+    pred.commit()
+
+
+def recompute_standings(league_id: int, pred=None) -> None:
+    """
+    Recompute standings from CURRENT roster ownership (full-reattribution model).
+
+    Team total = sum of fantasy_game_scores.points for players currently on the
+    manager's roster. Using current ownership (rather than the frozen user_id on
+    score rows) means a released player's points stop counting for the old owner
+    and an acquired player's full history counts for the new owner.
+    """
+    from app.models.fantasy_standings import FantasyStandings
+    if pred is None:
+        pred = PredSession()
+
+    now = datetime.now(timezone.utc)
+    week_ago = now - timedelta(days=7)
+
+    managers = pred.execute(
+        select(FantasyManager.user_id).where(FantasyManager.league_id == league_id)
+    ).scalars().all()
+
+    # Sum points per current-owner by joining scores to the live roster.
+    total_rows = pred.execute(
+        select(
+            FantasyRoster.user_id,
+            func.coalesce(func.sum(FantasyGameScores.points), 0).label("total"),
+        )
+        .select_from(FantasyRoster)
+        .join(
+            FantasyGameScores,
+            (FantasyGameScores.league_id == FantasyRoster.league_id)
+            & (FantasyGameScores.hb_human_id == FantasyRoster.hb_human_id),
+        )
+        .where(FantasyRoster.league_id == league_id)
+        .group_by(FantasyRoster.user_id)
+    ).all()
+    total_map = {r.user_id: float(r.total or 0) for r in total_rows}
+
+    # Week points — restrict to games in the last 7 days (by HB game date).
+    week_map: dict[int, float] = {}
+    try:
+        from app.db import HBSession
+        from sqlalchemy import text as sa_text
+        hb = HBSession()
+        game_ids = pred.execute(
+            select(FantasyGameScores.game_id)
+            .where(FantasyGameScores.league_id == league_id)
+            .distinct()
+        ).scalars().all()
+        recent_ids: set[int] = set()
+        if game_ids:
+            ids_sql = ",".join(str(int(g)) for g in game_ids)
+            recent = hb.execute(sa_text(
+                f"SELECT id FROM games WHERE id IN ({ids_sql}) AND date >= :cutoff"
+            ), {"cutoff": week_ago.date()}).fetchall()
+            recent_ids = {r.id for r in recent}
+        if recent_ids:
+            week_rows = pred.execute(
+                select(
+                    FantasyRoster.user_id,
+                    func.coalesce(func.sum(FantasyGameScores.points), 0).label("wtotal"),
+                )
+                .select_from(FantasyRoster)
+                .join(
+                    FantasyGameScores,
+                    (FantasyGameScores.league_id == FantasyRoster.league_id)
+                    & (FantasyGameScores.hb_human_id == FantasyRoster.hb_human_id),
+                )
+                .where(
+                    FantasyRoster.league_id == league_id,
+                    FantasyGameScores.game_id.in_(recent_ids),
+                )
+                .group_by(FantasyRoster.user_id)
+            ).all()
+            week_map = {r.user_id: float(r.wtotal or 0) for r in week_rows}
+    except Exception as e:
+        logger.warning("[trade] week_points recompute failed: %s", e)
+        try:
+            hb.rollback()
+        except Exception:
+            pass
+
+    # Rank all managers (include those with 0 points / empty rosters).
+    all_users = set(managers) | set(total_map.keys())
+    ranked = sorted(all_users, key=lambda uid: total_map.get(uid, 0.0), reverse=True)
+
+    for rank, uid in enumerate(ranked, 1):
+        stmt = pg_insert(FantasyStandings).values(
+            league_id=league_id,
+            user_id=uid,
+            total_points=total_map.get(uid, 0.0),
+            week_points=week_map.get(uid, 0.0),
+            rank=rank,
+            updated_at=now,
+        ).on_conflict_do_update(
+            constraint="uq_fantasy_standings_league_user",
+            set_={
+                "total_points": total_map.get(uid, 0.0),
+                "week_points": week_map.get(uid, 0.0),
+                "rank": rank,
+                "updated_at": now,
+            },
+        )
+        pred.execute(stmt)
+    pred.commit()
+
+
+def get_round_state(league_id: int, viewer_user_id: int | None = None) -> dict:
+    """
+    Return the current trade-round state for the league page:
+      {
+        "round": {...} | None,
+        "turns": [...],
+        "current_turn": {...} | None,
+        "is_my_turn": bool,
+        "can_initiate": bool (caller is creator + no active round + active league),
+      }
+    """
+    pred = PredSession()
+    league = pred.get(FantasyLeague, league_id)
+    if league is None:
+        return {"round": None, "turns": [], "current_turn": None,
+                "is_my_turn": False, "can_initiate": False}
+
+    rnd = _active_round(league_id, pred)
+    is_creator = viewer_user_id is not None and league.created_by == viewer_user_id
+
+    if rnd is None:
+        return {
+            "round": None,
+            "turns": [],
+            "current_turn": None,
+            "is_my_turn": False,
+            "can_initiate": bool(is_creator and league.status == "active"),
+        }
+
+    turns = pred.execute(
+        select(FantasyTradeTurn)
+        .where(FantasyTradeTurn.round_id == rnd.id)
+        .order_by(FantasyTradeTurn.pass_number.asc(), FantasyTradeTurn.turn_order.asc())
+    ).scalars().all()
+    current = _current_turn(rnd.id, pred)
+
+    return {
+        "round": rnd.to_dict(),
+        "turns": [t.to_dict() for t in turns],
+        "current_turn": current.to_dict() if current else None,
+        "is_my_turn": bool(current and viewer_user_id and current.user_id == viewer_user_id),
+        "can_initiate": False,  # already one in progress
+    }
+
+
+def _notify_turn(user_id: int, league_id: int, deadline, pred) -> None:
+    """Notify a manager it's their turn to trade (mirrors draft notifications)."""
+    try:
+        from app.services.notify_service import notify_user, DRAFT_NOTIFY_DELAY_SECONDS
+        deadline_str = deadline.astimezone().strftime("%b %d %I:%M %p %Z") if deadline else "soon"
+        league_name = ""
+        try:
+            lg = pred.get(FantasyLeague, league_id)
+            if lg:
+                league_name = f" · {lg.name}"
+        except Exception:
+            pass
+        notify_user(
+            db=pred,
+            user_id=user_id,
+            title=f"🔁 Your Trade Turn!{league_name}",
+            body=f"You're on the clock — make a trade or skip. Deadline {deadline_str}.",
+            url=f"/fantasy/{league_id}?tab=trade",
+            notif_type="fantasy_trade",
+            delay_seconds=DRAFT_NOTIFY_DELAY_SECONDS,
+        )
+        pred.commit()
+    except Exception as e:
+        logger.warning("[trade] could not notify user=%d: %s", user_id, e)

--- a/frontend/src/views/FantasyLeagueView.vue
+++ b/frontend/src/views/FantasyLeagueView.vue
@@ -50,6 +50,17 @@
             >
               {{ linkCopied ? '✅ Copied!' : '🔗 Share' }}
             </button>
+            <!-- Start Trade Round — creator only, active league, no round in progress -->
+            <button
+              v-if="league.is_creator && league.status === 'active' && !tradeState.round"
+              class="btn btn-secondary btn-xs"
+              :disabled="initiatingTrade"
+              @click="initiateTradeRound"
+              title="Start a mid-season trade round"
+            >
+              <span v-if="initiatingTrade" class="loading loading-spinner loading-xs"></span>
+              🔁 Start Trade Round
+            </button>
             <!-- Join button -->
             <button
               v-if="!league.is_member && ['forming', 'draft_open'].includes(league.status)"
@@ -567,6 +578,138 @@
           <RosterList :league-id="league.id" :user-id="myUserId" show-points />
         </div>
       </div>
+
+      <!-- ── Trade Tab ── -->
+      <div v-if="activeTab === 'trade'">
+        <!-- No round in progress -->
+        <div v-if="!tradeState.round" class="text-center py-10 text-base-content/40">
+          <div class="text-4xl mb-2">🔁</div>
+          <p class="font-medium">No trade round in progress.</p>
+          <p v-if="league.is_creator" class="text-sm mt-1">Use “Start Trade Round” in the header to begin one.</p>
+        </div>
+
+        <div v-else>
+          <!-- Turn status banner -->
+          <div class="alert mb-4" :class="tradeState.is_my_turn ? 'alert-success' : 'alert-info'">
+            <div>
+              <p class="font-semibold">
+                <template v-if="tradeState.is_my_turn">⬆️ It's your turn to trade!</template>
+                <template v-else-if="tradeState.current_turn">
+                  🕐 Waiting on {{ tradeManagerName(tradeState.current_turn.user_id) }}
+                </template>
+                <template v-else>Trade round {{ tradeState.round.status === 'completed' ? 'completed' : 'in progress' }}.</template>
+              </p>
+              <p v-if="tradeState.current_turn?.deadline" class="text-sm opacity-70 mt-0.5">
+                Deadline: {{ formatDeadline(tradeState.current_turn.deadline) }}
+              </p>
+            </div>
+          </div>
+
+          <!-- Turn order list -->
+          <div class="mb-6">
+            <h4 class="text-xs font-semibold uppercase tracking-wide text-base-content/50 mb-2">Turn Order (lowest fantasy points first)</h4>
+            <div class="flex flex-wrap gap-2">
+              <span
+                v-for="t in tradeState.turns"
+                :key="t.id"
+                class="badge gap-1"
+                :class="{
+                  'badge-success': tradeState.current_turn && t.id === tradeState.current_turn.id,
+                  'badge-ghost': t.is_resolved,
+                  'badge-outline': !t.is_resolved && (!tradeState.current_turn || t.id !== tradeState.current_turn.id),
+                }"
+                :title="t.pass_number === 2 ? 'Second-chance turn' : ''"
+              >
+                <span v-if="t.pass_number === 2">↻</span>
+                {{ tradeManagerName(t.user_id) }}
+                <template v-if="t.acquired_hb_human_id">✅</template>
+                <template v-else-if="t.is_skipped">⏭️</template>
+                <template v-else-if="t.is_missed">⌛</template>
+              </span>
+            </div>
+          </div>
+
+          <!-- The trade UI — only when it's my turn -->
+          <div v-if="tradeState.is_my_turn">
+            <div v-if="tradeError" class="alert alert-error mb-3 py-2 text-sm">{{ tradeError }}</div>
+
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <!-- LEFT: my roster (select someone to release) -->
+              <div class="card bg-base-200 p-3">
+                <h4 class="font-semibold mb-2 text-sm">1. Select a player to release</h4>
+                <div v-if="tradeRosterLoading" class="py-6 text-center"><span class="loading loading-spinner"></span></div>
+                <ul v-else class="space-y-1">
+                  <li
+                    v-for="p in myTradeRoster"
+                    :key="p.hb_human_id"
+                    class="flex items-center justify-between px-2 py-1.5 rounded-lg cursor-pointer hover:bg-base-300"
+                    :class="{ 'bg-primary/20 ring-1 ring-primary': tradeSelectedRelease === p.hb_human_id }"
+                    @click="selectRelease(p)"
+                  >
+                    <span class="truncate">
+                      {{ p.player_name || (p.first_name + ' ' + p.last_name) }}
+                      <span class="badge badge-xs ml-1" :class="p.is_goalie ? 'badge-info' : p.is_ref ? 'badge-warning' : 'badge-ghost'">
+                        {{ p.is_goalie ? 'G' : p.is_ref ? 'Ref' : 'Skater' }}
+                      </span>
+                    </span>
+                    <span class="text-xs font-mono opacity-70">{{ Number(p.fantasy_points).toFixed(1) }}</span>
+                  </li>
+                </ul>
+              </div>
+
+              <!-- RIGHT: available candidates (placeholder until release selected) -->
+              <div class="card bg-base-200 p-3">
+                <h4 class="font-semibold mb-2 text-sm">2. Select a replacement</h4>
+                <div v-if="!tradeSelectedRelease" class="py-10 text-center text-base-content/40 text-sm">
+                  ← Pick someone to release first
+                </div>
+                <div v-else-if="tradeAvailableLoading" class="py-6 text-center"><span class="loading loading-spinner"></span></div>
+                <div v-else-if="tradeAvailable.length === 0" class="py-10 text-center text-base-content/40 text-sm">
+                  No available players of this type.
+                </div>
+                <ul v-else class="space-y-1 max-h-96 overflow-y-auto">
+                  <li
+                    v-for="p in tradeAvailable"
+                    :key="p.hb_human_id"
+                    class="flex items-center justify-between px-2 py-1.5 rounded-lg cursor-pointer hover:bg-base-300"
+                    :class="{ 'bg-secondary/20 ring-1 ring-secondary': tradeSelectedAcquire === p.hb_human_id }"
+                    @click="selectAcquire(p)"
+                  >
+                    <span class="truncate">
+                      {{ p.player_name || (p.first_name + ' ' + p.last_name) }}
+                      <span class="badge badge-xs ml-1" :class="p.is_goalie ? 'badge-info' : p.is_ref ? 'badge-warning' : 'badge-ghost'">
+                        {{ p.is_goalie ? 'G' : p.is_ref ? 'Ref' : 'Skater' }}
+                      </span>
+                    </span>
+                    <span class="text-xs font-mono opacity-70">{{ Number(p.fantasy_points).toFixed(1) }}</span>
+                  </li>
+                </ul>
+              </div>
+            </div>
+
+            <!-- Confirmation prompt -->
+            <div v-if="tradeSelectedRelease && tradeSelectedAcquire" class="alert mt-4 flex-col items-stretch gap-2">
+              <p class="text-sm">
+                Release <strong>{{ releaseName }}</strong> and add <strong>{{ acquireName }}</strong> to your team?
+              </p>
+              <div class="flex gap-2">
+                <button class="btn btn-primary btn-sm" :disabled="tradeSubmitting" @click="confirmTrade">
+                  <span v-if="tradeSubmitting" class="loading loading-spinner loading-xs"></span>
+                  Confirm Trade
+                </button>
+                <button class="btn btn-ghost btn-sm" :disabled="tradeSubmitting" @click="tradeSelectedAcquire = null">Cancel</button>
+              </div>
+            </div>
+
+            <!-- Skip option -->
+            <div class="mt-4 text-center">
+              <button class="btn btn-outline btn-sm" :disabled="tradeSubmitting" @click="skipTrade">
+                I like my team — skip my turn
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
     </template>
 
     <div v-else class="text-center py-16 text-base-content/40">
@@ -728,11 +871,24 @@ const games = ref([])
 const gamesLoading = ref(false)
 const viewUserId = ref(null)  // whose roster to show in games tab (null = own)
 
+// ── Trade state ──────────────────────────────────────────────────────────────
+const tradeState = ref({ round: null, turns: [], current_turn: null, is_my_turn: false, can_initiate: false })
+const myTradeRoster = ref([])         // current user's roster (for the release list)
+const tradeRosterLoading = ref(false)
+const tradeSelectedRelease = ref(null)   // hb_human_id selected on the left
+const tradeAvailable = ref([])           // candidates of the released player's type
+const tradeAvailableLoading = ref(false)
+const tradeSelectedAcquire = ref(null)   // hb_human_id selected on the right
+const tradeSubmitting = ref(false)
+const tradeError = ref('')
+const initiatingTrade = ref(false)
+
 const allTabs = [
   { id: 'standings', label: '🏆 Standings' },
   { id: 'games', label: '🏒 Games' },
   { id: 'myteam', label: '⭐ My Team' },
   { id: 'rosters', label: '👥 Rosters' },
+  { id: 'trade', label: '🔁 Trade' },
   { id: 'draft', label: '📋 Draft' },
 ]
 const tabs = computed(() => {
@@ -742,6 +898,8 @@ const tabs = computed(() => {
   return allTabs.filter(t => {
     if (t.id === 'draft' && isLive) return false
     if (t.id === 'games' && !hasGames) return false
+    // Trade tab only while active, and only once a trade round exists (or it's your turn).
+    if (t.id === 'trade' && !(league.value.status === 'active' && tradeState.value.round)) return false
     return true
   })
 })
@@ -1162,6 +1320,133 @@ async function loadStandings() {
   }
 }
 
+// ── Trade loaders + actions ──────────────────────────────────────────────────
+async function loadTradeState({ silent = false } = {}) {
+  try {
+    const { data } = await api.get(`/api/fantasy/leagues/${route.params.id}/trade`)
+    tradeState.value = data
+  } catch {
+    if (!silent) tradeState.value = { round: null, turns: [], current_turn: null, is_my_turn: false, can_initiate: false }
+  }
+}
+
+// Map a manager user_id → team/display name for the turn list.
+const tradeManagerName = (userId) => {
+  const s = standings.value.find(s => s.user_id === userId)
+  return s?.team_name || s?.display_name || `Manager ${userId}`
+}
+
+async function loadMyTradeRoster() {
+  if (!myUserId.value) return
+  tradeRosterLoading.value = true
+  try {
+    const { data } = await api.get(`/api/fantasy/leagues/${route.params.id}/roster/${myUserId.value}`)
+    myTradeRoster.value = data.roster || []
+  } catch {
+    myTradeRoster.value = []
+  } finally {
+    tradeRosterLoading.value = false
+  }
+}
+
+// Role string for a roster player → matches backend type filter.
+function playerType(p) {
+  if (p.is_goalie) return 'goalie'
+  if (p.is_ref) return 'ref'
+  return 'skater'
+}
+
+// Step 1: select a player to release → load available candidates of the same type.
+async function selectRelease(player) {
+  tradeError.value = ''
+  tradeSelectedAcquire.value = null
+  tradeSelectedRelease.value = player.hb_human_id
+  tradeAvailableLoading.value = true
+  tradeAvailable.value = []
+  try {
+    const type = playerType(player)
+    const { data } = await api.get(
+      `/api/fantasy/leagues/${route.params.id}/trade/available?type=${type}`
+    )
+    tradeAvailable.value = data.players || []
+  } catch (e) {
+    tradeError.value = e?.response?.data?.message || 'Could not load available players'
+  } finally {
+    tradeAvailableLoading.value = false
+  }
+}
+
+// Step 2: select a candidate to acquire (shows the confirm prompt in the template).
+function selectAcquire(player) {
+  tradeError.value = ''
+  tradeSelectedAcquire.value = player.hb_human_id
+}
+
+const releaseName = computed(() => {
+  const p = myTradeRoster.value.find(p => p.hb_human_id === tradeSelectedRelease.value)
+  return p ? (p.player_name || `${p.first_name} ${p.last_name}`) : ''
+})
+const acquireName = computed(() => {
+  const p = tradeAvailable.value.find(p => p.hb_human_id === tradeSelectedAcquire.value)
+  return p ? (p.player_name || `${p.first_name} ${p.last_name}`) : ''
+})
+
+function resetTradeSelection() {
+  tradeSelectedRelease.value = null
+  tradeSelectedAcquire.value = null
+  tradeAvailable.value = []
+  tradeError.value = ''
+}
+
+async function confirmTrade() {
+  if (!tradeSelectedRelease.value || !tradeSelectedAcquire.value) return
+  tradeSubmitting.value = true
+  tradeError.value = ''
+  try {
+    await api.post(`/api/fantasy/leagues/${route.params.id}/trade/swap`, {
+      release_hb_human_id: tradeSelectedRelease.value,
+      acquire_hb_human_id: tradeSelectedAcquire.value,
+    })
+    resetTradeSelection()
+    // Refresh trade-state first (it advances the turn), then roster/standings.
+    await loadTradeState()
+    await Promise.all([loadMyTradeRoster(), loadStandings(), loadLeague({ silent: true })])
+  } catch (e) {
+    tradeError.value = e?.response?.data?.message || 'Trade failed'
+  } finally {
+    tradeSubmitting.value = false
+  }
+}
+
+async function skipTrade() {
+  tradeSubmitting.value = true
+  tradeError.value = ''
+  try {
+    await api.post(`/api/fantasy/leagues/${route.params.id}/trade/skip`)
+    resetTradeSelection()
+    await loadTradeState()
+    await Promise.all([loadMyTradeRoster(), loadStandings()])
+  } catch (e) {
+    tradeError.value = e?.response?.data?.message || 'Could not skip'
+  } finally {
+    tradeSubmitting.value = false
+  }
+}
+
+async function initiateTradeRound() {
+  if (!confirm('Start a trade round now? Managers will take turns (lowest fantasy points first) to make one swap each.')) return
+  initiatingTrade.value = true
+  try {
+    await api.post(`/api/fantasy/leagues/${route.params.id}/trade/initiate`, {})
+    await Promise.all([loadTradeState(), loadStandings(), loadMyTradeRoster()])
+    activeTab.value = 'trade'
+  } catch (e) {
+    alert(e?.response?.data?.message || 'Could not start trade round')
+  } finally {
+    initiatingTrade.value = false
+  }
+}
+
 async function joinLeague() {
   joinError.value = ''
   joining.value = true
@@ -1246,6 +1531,7 @@ watch(() => league.value?.has_live_game, (hasLive) => {
       await loadLeague({ silent: true })
       if (activeTab.value === 'games') loadGames(viewUserId.value)
       if (activeTab.value === 'standings') loadStandings()
+      if (league.value?.status === 'active') loadTradeState({ silent: true })
     }, 60000)
   }
 }, { immediate: true })
@@ -1265,6 +1551,10 @@ watch(activeTab, (tab) => {
   if (tab === 'standings') loadStandings()
   if (tab === 'games') loadGames()
   if (tab === 'draft') loadMyQueue()
+  if (tab === 'trade') {
+    resetTradeSelection()
+    loadTradeState().then(() => Promise.all([loadMyTradeRoster(), loadStandings()]))
+  }
 })
 
 // Auto-switch pool tab based on pick type
@@ -1295,10 +1585,15 @@ onMounted(async () => {
   }
 
   await loadLeague()
+  // Load trade state up front so the Trade tab + header button can appear.
+  if (league.value && league.value.status === 'active') {
+    await loadTradeState({ silent: true })
+  }
   // Honor ?tab=draft (or other tab) from notification link
   const tabParam = route.query.tab
   if (tabParam && tabs.value.some(t => t.id === tabParam)) {
     activeTab.value = tabParam
+    if (tabParam === 'trade') loadTradeState().then(() => Promise.all([loadMyTradeRoster(), loadStandings()]))
   }
   // Pre-fill join code only if league is still open for new members
   const urlCode = route.query.join_code

--- a/migrations/versions/v2w3x4y5z6a7_add_fantasy_trade_rounds_and_turns.py
+++ b/migrations/versions/v2w3x4y5z6a7_add_fantasy_trade_rounds_and_turns.py
@@ -1,0 +1,56 @@
+"""add fantasy_trade_rounds and fantasy_trade_turns
+
+Revision ID: v2w3x4y5z6a7
+Revises: u1v2w3x4y5z6
+Create Date: 2026-06-28
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = 'v2w3x4y5z6a7'
+down_revision = 'u1v2w3x4y5z6'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'fantasy_trade_rounds',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('league_id', sa.Integer(), sa.ForeignKey('fantasy_leagues.id'), nullable=False),
+        sa.Column('status', sa.String(length=20), nullable=False, server_default='active'),
+        sa.Column('pick_hours', sa.Integer(), nullable=False, server_default='24'),
+        sa.Column('created_by', sa.Integer(), sa.ForeignKey('pred_users.id'), nullable=True),
+        sa.Column('created_at', sa.DateTime(timezone=True), nullable=False,
+                  server_default=sa.text('now()')),
+        sa.Column('completed_at', sa.DateTime(timezone=True), nullable=True),
+    )
+    op.create_index('ix_fantasy_trade_rounds_league', 'fantasy_trade_rounds', ['league_id'])
+
+    op.create_table(
+        'fantasy_trade_turns',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('round_id', sa.Integer(), sa.ForeignKey('fantasy_trade_rounds.id'), nullable=False),
+        sa.Column('league_id', sa.Integer(), nullable=False),
+        sa.Column('user_id', sa.Integer(), sa.ForeignKey('pred_users.id'), nullable=False),
+        sa.Column('turn_order', sa.Integer(), nullable=False),
+        sa.Column('pass_number', sa.Integer(), nullable=False, server_default='1'),
+        sa.Column('released_hb_human_id', sa.Integer(), nullable=True),
+        sa.Column('acquired_hb_human_id', sa.Integer(), nullable=True),
+        sa.Column('is_skipped', sa.Boolean(), nullable=False, server_default='false'),
+        sa.Column('is_missed', sa.Boolean(), nullable=False, server_default='false'),
+        sa.Column('deadline', sa.DateTime(timezone=True), nullable=True),
+        sa.Column('acted_at', sa.DateTime(timezone=True), nullable=True),
+        sa.Column('created_at', sa.DateTime(timezone=True), nullable=False,
+                  server_default=sa.text('now()')),
+        sa.UniqueConstraint('round_id', 'user_id', 'pass_number',
+                            name='uq_fantasy_trade_turns_round_user_pass'),
+    )
+    op.create_index('ix_fantasy_trade_turns_round', 'fantasy_trade_turns', ['round_id'])
+
+
+def downgrade():
+    op.drop_index('ix_fantasy_trade_turns_round', table_name='fantasy_trade_turns')
+    op.drop_table('fantasy_trade_turns')
+    op.drop_index('ix_fantasy_trade_rounds_league', table_name='fantasy_trade_rounds')
+    op.drop_table('fantasy_trade_rounds')


### PR DESCRIPTION
## Summary

Adds a **mid-season trade** system for active fantasy leagues. The league creator starts a trade round; managers take turns swapping one player each.

## How it works

- **Creator initiates** a trade round via a button in the league header.
- **Turn order** = managers by ascending fantasy points (lowest FP goes first).
- On their turn a manager **releases one rostered player and acquires one available player of the same type** (skater/goalie/ref), or **skips**.
- **24h default** per turn. A missed turn advances to the next manager; managers who missed get a **second-chance round-robin pass** before the round completes.
- **Available players** = the current-season pool (`hb_season_id`) minus everyone currently rostered — so new-this-season players and released players become available (as opposed to the draft's previous-season pool).

## Point attribution

**Full reattribution:** when a player is acquired, their entire season's `fantasy_game_scores` are reassigned to the new owner. Standings recompute on the fly by summing scores joined to the **current** roster, so a released player's points stop counting for the old owner and an acquired player's full history counts for the new one.

## Changes

**Backend**
- Models: `FantasyTradeRound`, `FantasyTradeTurn` + Alembic migration `v2w3x4y5z6a7`
- Service: `fantasy_trade_service` — turn state machine, swap/skip, point reattribution, standings recompute, second-chance pass, deadline advancement
- Endpoints: `GET /trade`, `GET /trade/available`, `POST /trade/initiate`, `POST /trade/swap`, `POST /trade/skip`
- Scheduler: `advance-trades` job (mirrors the draft-advance job) to expire turn deadlines
- App factory: `DISABLE_SCHEDULER` env flag to run dev instances without background jobs

**Frontend** (`FantasyLeagueView.vue`)
- **Trade tab**: two-list flow — select a roster player to release → the right list populates with available candidates of that type → select one → confirm ("Release X and add Y?"). Plus a skip option and turn-order display.
- **"Start Trade Round"** button in the header for the creator.

## Testing

Verified against a copy of the predictions DB (real league data):
- State-machine E2E (turn order, swap + reattribution, wrong-turn/cross-type rejection, skip, missed→second-chance, completion, standings re-rank)
- Endpoint-level (authz 403, validation 400, conflict 409, happy-path 200)
- Manual UI walkthrough of the full flow
- Frontend builds clean

## Deploy notes

- Includes a DB migration — `pull_and_deploy.sh` runs `alembic upgrade head`, which will create `fantasy_trade_rounds` / `fantasy_trade_turns`. No backfill needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)