### PR TITLE
fix: acquired free-agent players show 0 fantasy points after trade

### DIFF
--- a/app/services/fantasy_scoring_service.py
+++ b/app/services/fantasy_scoring_service.py
@@ -741,6 +741,38 @@ def score_active_leagues() -> dict:
     return summary
 
 
+def backfill_scoring_after_trade(league_id: int) -> int:
+    """
+    Re-score every already-scored game in a league so that a newly-acquired
+    player (who was NOT on any roster when the games were originally scored, e.g.
+    a free agent picked up in a trade) gets their fantasy_game_scores rows
+    created for the first time.
+
+    score_game() only records rows for players CURRENTLY on a roster. Reattributing
+    existing rows on a trade therefore does nothing for a player who never had rows.
+    Re-running score_game for the league's finalized games fixes that: it upserts
+    (idempotent) for players who already have rows, and creates rows for the newly
+    rostered player. Returns the number of games re-scored.
+    """
+    pred = PredSession()
+    scored_game_ids = [
+        r.game_id
+        for r in pred.execute(
+            text("SELECT DISTINCT game_id FROM fantasy_game_scores "
+                 "WHERE league_id = :lid AND is_provisional = FALSE"),
+            {"lid": league_id},
+        ).fetchall()
+    ]
+    for gid in scored_game_ids:
+        try:
+            score_game(league_id, gid)
+        except Exception as e:
+            logger.warning("[fantasy] backfill score_game(%d, %d) failed: %s", league_id, gid, e)
+    logger.info("[fantasy] backfill_scoring_after_trade league=%d rescored=%d games",
+                league_id, len(scored_game_ids))
+    return len(scored_game_ids)
+
+
 def _update_standings(league_id: int, pred) -> None:
     """Recompute total_points and week_points for all managers and update rank."""
     from sqlalchemy import func

--- a/app/services/fantasy_trade_service.py
+++ b/app/services/fantasy_trade_service.py
@@ -457,10 +457,24 @@ def make_trade(league_id: int, user_id: int, release_hb_human_id: int,
     released.drafted_at = now
     pred.commit()
 
-    # FULL REATTRIBUTION: any existing scores for the acquired player in this
-    # league now belong to the new owner. (Released player's past scores stay as
-    # historical rows but are no longer on anyone's roster, so they drop out of
-    # team totals — see recompute_standings, which sums by current ownership.)
+    # SCORE + REATTRIBUTE the acquired player.
+    #
+    # score_game() only ever creates rows for players who were rostered at scoring
+    # time, so a free agent picked up in a trade (never previously rostered in this
+    # league) has NO score rows to reattribute. Now that the roster swap above has
+    # made them rostered under the new owner, re-score the league's already-scored
+    # games so their historical games are recorded for this owner (cheap: only the
+    # games the league has already scored). This creates rows for a never-scored
+    # acquisition and refreshes rows for a previously-rostered one.
+    try:
+        from app.services.fantasy_scoring_service import backfill_scoring_after_trade
+        backfill_scoring_after_trade(league_id)
+    except Exception as e:
+        logger.warning("[trade] backfill scoring failed for league=%d acquire=%d: %s",
+                       league_id, acquire_hb_human_id, e)
+
+    # Belt-and-suspenders: reassign any remaining rows for the acquired player to
+    # the new owner (covers score rows in games outside the re-scored set).
     _reassign_player_scores(league_id, acquire_hb_human_id, user_id, pred)
 
     # Record the turn outcome.


### PR DESCRIPTION
## Bug

After acquiring a player who was **never previously rostered** in the league (a free agent), their fantasy points show as **0** in the roster/standings — even though the full-reattribution model promises the new owner gets the player's accumulated points. Reported live on league 121 (Jeremy Thurston).

## Root cause

`score_game()` only creates `fantasy_game_scores` rows for players **currently on a roster**. A free agent had no score rows, so the trade's reattribution (which only *moves* existing rows) had nothing to move → 0 points.

The "points" shown next to selectable players in the trade UI come from a **different** source — the pool service's whole-season division-stat aggregate — which is why the number appeared but never landed in standings.

## Fix

In `make_trade()`, after the roster swap makes the acquired player rostered under the new owner, call `backfill_scoring_after_trade()` to re-score the league's already-scored games. This creates the acquired player's score rows for the new owner. It's an idempotent upsert, so previously-rostered players are unaffected. The existing reattribution is kept as a belt-and-suspenders for rows outside the re-scored set.

## Not changed (intentional)

Standings points reflect **per-game scoring within the league's tracked window** (games since `season_starts_at` in the tracked division). This can differ from the whole-season division-stat aggregate shown as the draft/trade "FP" number. Reconciling those two is a separate product decision about the scoring window, not part of this bug.

## Testing

Against a copy of prod (league 121, reproduced the exact live state):
- Thurston: **0 → 23.0 pts**, all owned by the acquiring manager; standings recomputed.
- Repeat backfill is **idempotent** (no double-counting) — verified no player's total changes on a second run.
- Compiles clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)