### PR TITLE
fix: show middle name in fantasy player names (disambiguate same-name players)

### DIFF
--- a/app/blueprints/fantasy.py
+++ b/app/blueprints/fantasy.py
@@ -30,6 +30,7 @@ from app.models.fantasy_roster import FantasyRoster
 from app.models.fantasy_draft_queue import FantasyDraftQueue
 from app.models.fantasy_standings import FantasyStandings
 from app.models.pred_user import PredUser
+from app.utils.names import format_player_name
 from app.utils.response import error_response
 from hockey_blast_common_lib.game_status import StatusId, FINAL_STATUS_IDS
 
@@ -828,7 +829,7 @@ def get_draft_queue(league_id: int):
             humans = hb.execute(
                 select(Human).where(Human.id.in_(picked_ids))
             ).scalars().all()
-            human_names = {h.id: f"{h.first_name} {h.last_name}".strip() for h in humans}
+            human_names = {h.id: format_player_name(h.first_name, h.middle_name, h.last_name) for h in humans}
 
     # Manager names
     mgr_stmt = (
@@ -1112,8 +1113,9 @@ def get_roster(league_id: int, user_id: int):
         h = human_map.get(r.hb_human_id)
         if h:
             d["first_name"] = h.first_name
+            d["middle_name"] = h.middle_name
             d["last_name"] = h.last_name
-            d["player_name"] = f"{h.first_name} {h.last_name}".strip()
+            d["player_name"] = format_player_name(h.first_name, h.middle_name, h.last_name)
         s = stats_map.get(r.hb_human_id, {})
         d["goals"] = s.get("goals", 0)
         d["assists"] = s.get("assists", 0)
@@ -1234,9 +1236,9 @@ def get_league_games(league_id: int):
         if my_roster:
             hids_sql = ",".join(str(h) for h in my_roster)
             human_rows = hb.execute(
-                text(f"SELECT id, first_name, last_name FROM humans WHERE id IN ({hids_sql})")
+                text(f"SELECT id, first_name, middle_name, last_name FROM humans WHERE id IN ({hids_sql})")
             ).fetchall()
-            human_names = {r.id: f"{r.first_name or ''} {r.last_name or ''}".strip() for r in human_rows}
+            human_names = {r.id: format_player_name(r.first_name, r.middle_name, r.last_name) for r in human_rows}
 
     # Batch-load scores for completed games
     scored_games = {r.id for r in game_rows if r.status_id in FINAL_STATUS_IDS}
@@ -1471,8 +1473,9 @@ def get_trade_available(league_id: int):
         result.append({
             "hb_human_id": hid,
             "first_name": p.get("first_name"),
+            "middle_name": p.get("middle_name"),
             "last_name": p.get("last_name"),
-            "player_name": f"{p.get('first_name', '')} {p.get('last_name', '')}".strip(),
+            "player_name": format_player_name(p.get("first_name"), p.get("middle_name"), p.get("last_name")),
             "is_skater": p.get("is_skater", False),
             "is_goalie": p.get("is_goalie", False),
             "is_ref": p.get("is_ref", False),

--- a/app/services/fantasy_pool_service.py
+++ b/app/services/fantasy_pool_service.py
@@ -132,10 +132,11 @@ def get_player_pool(level_id: int, org_id: int = 1, league_id: int = None, seaso
     # ── Unified player dict keyed by human_id ─────────────────────────────────
     players: dict[int, dict] = {}
 
-    def _base_entry(human_id, first_name, last_name):
+    def _base_entry(human_id, first_name, last_name, middle_name=None):
         return {
             "hb_human_id": human_id,
             "first_name": first_name,
+            "middle_name": middle_name,
             "last_name": last_name,
             # Role flags
             "is_skater": False,
@@ -168,7 +169,7 @@ def get_player_pool(level_id: int, org_id: int = 1, league_id: int = None, seaso
     skater_stmt = (
         select(
             DivisionStatsSkater.human_id,
-            Human.first_name, Human.last_name,
+            Human.first_name, Human.middle_name, Human.last_name,
             func.sum(DivisionStatsSkater.games_played).label("games_played"),
             func.sum(DivisionStatsSkater.goals).label("goals"),
             func.sum(DivisionStatsSkater.assists).label("assists"),
@@ -178,7 +179,7 @@ def get_player_pool(level_id: int, org_id: int = 1, league_id: int = None, seaso
         .join(Human, Human.id == DivisionStatsSkater.human_id)
         .where(DivisionStatsSkater.division_id.in_(div_ids_stmt))
         .where(DivisionStatsSkater.human_id.not_in(non_human_ids) if non_human_ids else True)
-        .group_by(DivisionStatsSkater.human_id, Human.first_name, Human.last_name)
+        .group_by(DivisionStatsSkater.human_id, Human.first_name, Human.middle_name, Human.last_name)
         .having(func.sum(DivisionStatsSkater.games_played) >= min_games)
     )
     for row in hb.execute(skater_stmt).all():
@@ -187,7 +188,7 @@ def get_player_pool(level_id: int, org_id: int = 1, league_id: int = None, seaso
         assists = row.assists or 0
         penalties = row.penalties or 0
         fp = (goals * 3) + (assists * 2) + (gp * 1) - (penalties * 0.5)
-        p = players.setdefault(row.human_id, _base_entry(row.human_id, row.first_name, row.last_name))
+        p = players.setdefault(row.human_id, _base_entry(row.human_id, row.first_name, row.last_name, row.middle_name))
         p["is_skater"] = True
         p["games_played"] = row.games_played
         p["goals"] = goals
@@ -201,7 +202,7 @@ def get_player_pool(level_id: int, org_id: int = 1, league_id: int = None, seaso
     goalie_stmt = (
         select(
             DivisionStatsGoalie.human_id,
-            Human.first_name, Human.last_name,
+            Human.first_name, Human.middle_name, Human.last_name,
             func.sum(DivisionStatsGoalie.games_played).label("games_played"),
             func.sum(DivisionStatsGoalie.goals_allowed).label("goals_allowed"),
             func.avg(DivisionStatsGoalie.goals_allowed_per_game).label("goals_against_avg"),
@@ -210,14 +211,14 @@ def get_player_pool(level_id: int, org_id: int = 1, league_id: int = None, seaso
         .join(Human, Human.id == DivisionStatsGoalie.human_id)
         .where(DivisionStatsGoalie.division_id.in_(div_ids_stmt))
         .where(DivisionStatsGoalie.human_id.not_in(non_human_ids) if non_human_ids else True)
-        .group_by(DivisionStatsGoalie.human_id, Human.first_name, Human.last_name)
+        .group_by(DivisionStatsGoalie.human_id, Human.first_name, Human.middle_name, Human.last_name)
         .having(func.sum(DivisionStatsGoalie.games_played) >= min_games)
     )
     for row in hb.execute(goalie_stmt).all():
         gp = row.games_played or 1
         save_pct = float(row.save_percentage or 0)
         fp = float(gp) * 3.0 + (save_pct * 5.0 * gp)
-        p = players.setdefault(row.human_id, _base_entry(row.human_id, row.first_name, row.last_name))
+        p = players.setdefault(row.human_id, _base_entry(row.human_id, row.first_name, row.last_name, row.middle_name))
         p["is_goalie"] = True
         p["goalie_games"] = row.games_played
         p["goals_allowed"] = int(row.goals_allowed or 0)
@@ -230,7 +231,7 @@ def get_player_pool(level_id: int, org_id: int = 1, league_id: int = None, seaso
     ref_stmt = (
         select(
             DivisionStatsReferee.human_id,
-            Human.first_name, Human.last_name,
+            Human.first_name, Human.middle_name, Human.last_name,
             func.sum(DivisionStatsReferee.games_reffed).label("games_reffed"),
             func.sum(DivisionStatsReferee.penalties_given).label("penalties_given"),
             func.sum(DivisionStatsReferee.gm_given).label("gm_given"),
@@ -238,7 +239,7 @@ def get_player_pool(level_id: int, org_id: int = 1, league_id: int = None, seaso
         .join(Human, Human.id == DivisionStatsReferee.human_id)
         .where(DivisionStatsReferee.division_id.in_(div_ids_stmt))
         .where(DivisionStatsReferee.human_id.not_in(non_human_ids) if non_human_ids else True)
-        .group_by(DivisionStatsReferee.human_id, Human.first_name, Human.last_name)
+        .group_by(DivisionStatsReferee.human_id, Human.first_name, Human.middle_name, Human.last_name)
         .having(func.sum(DivisionStatsReferee.games_reffed) >= min_games)
     )
     for row in hb.execute(ref_stmt).all():
@@ -246,7 +247,7 @@ def get_player_pool(level_id: int, org_id: int = 1, league_id: int = None, seaso
         pg = int(row.penalties_given or 0)
         gm = int(row.gm_given or 0)
         fp = gr * 4.0 + pg * 2.0 + gm * 8.0
-        p = players.setdefault(row.human_id, _base_entry(row.human_id, row.first_name, row.last_name))
+        p = players.setdefault(row.human_id, _base_entry(row.human_id, row.first_name, row.last_name, row.middle_name))
         p["is_ref"] = True
         p["games_reffed"] = gr
         p["penalties_given"] = pg

--- a/app/services/fantasy_trade_service.py
+++ b/app/services/fantasy_trade_service.py
@@ -347,7 +347,8 @@ def _try_auto_trade_for_expired_turn(league_id: int, round_id: int, turn, pred) 
         if gain <= 0:
             continue  # no upgrade for this role
         if best_swap is None or gain > best_swap[0]:
-            name = f"{cand.get('first_name', '')} {cand.get('last_name', '')}".strip()
+            from app.utils.names import format_player_name
+            name = format_player_name(cand.get("first_name"), cand.get("middle_name"), cand.get("last_name"))
             best_swap = (gain, release_id, cand["hb_human_id"], role, name)
 
     if best_swap is None:
@@ -760,16 +761,17 @@ def _notify_turn(user_id: int, league_id: int, deadline, pred) -> None:
 
 
 def _hb_player_name(hb_human_id: int) -> str:
-    """Best-effort 'First Last' for a HB human id (for notifications)."""
+    """Best-effort 'First Middle Last' for a HB human id (for notifications)."""
     try:
         from app.db import HBSession
         from sqlalchemy import text as sa_text
+        from app.utils.names import format_player_name
         row = HBSession().execute(
-            sa_text("SELECT first_name, last_name FROM humans WHERE id = :hid"),
+            sa_text("SELECT first_name, middle_name, last_name FROM humans WHERE id = :hid"),
             {"hid": hb_human_id},
         ).fetchone()
         if row:
-            return f"{row.first_name or ''} {row.last_name or ''}".strip() or f"#{hb_human_id}"
+            return format_player_name(row.first_name, row.middle_name, row.last_name) or f"#{hb_human_id}"
     except Exception:
         pass
     return f"#{hb_human_id}"

--- a/app/utils/names.py
+++ b/app/utils/names.py
@@ -1,0 +1,13 @@
+"""Player name formatting helpers."""
+
+
+def format_player_name(first_name, middle_name=None, last_name=None) -> str:
+    """
+    Build a display name as "First Middle Last", skipping any empty parts.
+
+    Including the middle name/initial disambiguates distinct people who share a
+    first + last name (e.g. "Michael S Welch" vs "Michael J Welch"), matching how
+    the stats side renders names.
+    """
+    parts = [p.strip() for p in (first_name, middle_name, last_name) if p and str(p).strip()]
+    return " ".join(parts)

--- a/frontend/src/views/FantasyLeagueView.vue
+++ b/frontend/src/views/FantasyLeagueView.vue
@@ -250,7 +250,7 @@
                             <button class="btn btn-xs btn-disabled" title="Not your turn" disabled>—</button>
                           </template>
                         </td>
-                        <td><a :href="`http://hockey-blast.com/human_stats/human_stats?human_id=${p.hb_human_id}`" target="_blank" class="link link-hover text-blue-400">{{ p.first_name }} {{ p.last_name }}</a></td>
+                        <td><a :href="`http://hockey-blast.com/human_stats/human_stats?human_id=${p.hb_human_id}`" target="_blank" class="link link-hover text-blue-400">{{ displayName(p) }}</a></td>
                         <td class="text-right">{{ p.games_played }}</td>
                         <td class="text-right">{{ p.goals }}</td>
                         <td class="text-right">{{ p.assists }}</td>
@@ -311,7 +311,7 @@
                             <button class="btn btn-xs btn-disabled" title="Not your turn" disabled>—</button>
                           </template>
                         </td>
-                        <td><a :href="`http://hockey-blast.com/human_stats/human_stats?human_id=${p.hb_human_id}`" target="_blank" class="link link-hover text-blue-400">{{ p.first_name }} {{ p.last_name }}</a></td>
+                        <td><a :href="`http://hockey-blast.com/human_stats/human_stats?human_id=${p.hb_human_id}`" target="_blank" class="link link-hover text-blue-400">{{ displayName(p) }}</a></td>
                         <td class="text-right">{{ p.goalie_games ?? p.games_played }}</td>
                         <td class="text-right">{{ p.goals_against_avg ?? '—' }}</td>
                         <td class="text-right">{{ p.save_percentage != null ? (p.save_percentage * 100).toFixed(1) + '%' : '—' }}</td>
@@ -370,7 +370,7 @@
                             <button class="btn btn-xs btn-disabled" disabled>—</button>
                           </template>
                         </td>
-                        <td><a :href="`http://hockey-blast.com/human_stats/human_stats?human_id=${p.hb_human_id}`" target="_blank" class="link link-hover text-blue-400">{{ p.first_name }} {{ p.last_name }}</a></td>
+                        <td><a :href="`http://hockey-blast.com/human_stats/human_stats?human_id=${p.hb_human_id}`" target="_blank" class="link link-hover text-blue-400">{{ displayName(p) }}</a></td>
                         <td class="text-right">{{ p.games_reffed }}</td>
                         <td class="text-right">{{ p.penalties_given }}</td>
                         <td class="text-right">{{ p.gm_given }}</td>
@@ -1000,6 +1000,15 @@ function setRefSortKey(key) {
 }
 
 const myUserId = computed(() => userStore.predUser?.id)
+
+// Display name including middle name/initial when present, so distinct people
+// who share a first+last name (e.g. "Michael S Welch" vs "Michael J Welch") are
+// distinguishable. Prefers server-provided player_name, falls back to parts.
+function displayName(p) {
+  if (!p) return '—'
+  if (p.player_name) return p.player_name
+  return [p.first_name, p.middle_name, p.last_name].filter(Boolean).join(' ')
+}
 
 // Priority queue helpers
 const queuePositionOf = (hb_human_id) => {


### PR DESCRIPTION
## Bug

On `/fantasy/118`, the trade available-list showed **"Michael Welch" twice** — 18.5 and 4.0 — looking like a duplicate.

## Root cause

They're **two different people**: `hb_human_id` 163136 = *Michael **S** Welch* (18.5, 6 games) and 111984 = *Michael **J** Welch* (4.0, 1 game). Both legitimately play in the league's division this season, so both correctly appear in the pool. But fantasy name display was built from `first_name + last_name` **everywhere**, dropping `middle_name` — so distinct people collapsed to the same string. (The stats side already shows middle names, which is why it looked correct there.)

Not a trades bug and not a duplicate-identity data issue — a **display** bug.

## Fix

Include the middle name/initial in fantasy name display, matching the stats-side format:
- **`app/utils/names.py`** (new): `format_player_name(first, middle, last)` — joins non-empty parts.
- **`fantasy_pool_service`**: select / group by / carry `middle_name` through the player pool.
- **`fantasy` blueprint**: use the helper for the trade available list, roster, and games-view name maps; include `middle_name` in payloads.
- **`fantasy_trade_service`**: middle name in auto-trade notification names.
- **`FantasyLeagueView.vue`**: `displayName()` helper (prefers server `player_name`, falls back to first+middle+last) for the draft-pool tables that build names client-side.

## Verification

Against a prod copy (league 118), the trade available endpoint now returns **"Michael S Welch" (18.5)** and **"Michael J Welch" (4.0)** distinctly. Frontend builds clean; verified end-to-end via the running dev server.

## Deploy

No schema change. Frontend rebuild + restart (`pull_and_deploy.sh`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)